### PR TITLE
Removed unnecessary type conversion 

### DIFF
--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -554,21 +554,8 @@ def get_trackitem_openpype_data(track_item):
         key = k.replace("tag.", "")
 
         try:
-            # capture exceptions which are related to strings only
-            if re.match(r"^[\d]+$", v):
-                value = int(v)
-            elif re.match(r"^True$", v):
-                value = True
-            elif re.match(r"^False$", v):
-                value = False
-            elif re.match(r"^None$", v):
-                value = None
-            elif re.match(r"^[\w\d_]+$", v):
-                value = v
-            else:
-                value = ast.literal_eval(v)
-        except (ValueError, SyntaxError) as msg:
-            log.warning(msg)
+            value = ast.literal_eval(v)
+        except (ValueError, SyntaxError):
             value = v
 
         data[key] = value

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -438,13 +438,18 @@ def get_track_openpype_data(track, container_name=None):
 
     # get tag metadata attribute
     tag_data = deepcopy(dict(tag.metadata()))
+    if tag_data.get("tag.json_metadata"):
+        tag_data = json.loads(tag_data["tag.json_metadata"])
 
     for obj_name, obj_data in tag_data.items():
         obj_name = obj_name.replace("tag.", "")
 
         if obj_name in ["applieswhole", "note", "label"]:
             continue
-        return_data[obj_name] = json.loads(obj_data)
+        if isinstance(obj_data, dict):
+            return_data[obj_name] = obj_data
+        else:
+            return_data[obj_name] = json.loads(obj_data)
 
     return (
         return_data[container_name]

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -619,7 +619,7 @@ def set_publish_attribute(tag, value):
     # set data to the publish attribute
     metadata = json.loads(tag_data.get("tag.json_metadata"))
     metadata["publish"] = value
-    tag_data.setValue("tag.json_metadata", metadata)
+    tag.metadata().setValue("tag.json_metadata", metadata)
 
 
 def get_publish_attribute(tag):

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -549,6 +549,9 @@ def get_trackitem_openpype_data(track_item):
 
     # get tag metadata attribute
     tag_data = deepcopy(dict(tag.metadata()))
+    if tag_data.get("tag.json_metadata"):
+        return json.loads(tag_data.get("tag.json_metadata"))
+
     # convert tag metadata to normal keys names and values to correct types
     for k, v in tag_data.items():
         key = k.replace("tag.", "")
@@ -595,9 +598,11 @@ def set_publish_attribute(tag, value):
         tag (hiero.core.Tag): a tag object
         value (bool): True or False
     """
-    tag_data = tag.metadata()
+    tag_data = dict(tag.metadata())
     # set data to the publish attribute
-    tag_data.setValue("tag.publish", str(value))
+    metadata = json.loads(tag_data.get("tag.json_metadata"))
+    metadata["publish"] = value
+    tag_data.setValue("tag.json_metadata", metadata)
 
 
 def get_publish_attribute(tag):
@@ -609,9 +614,7 @@ def get_publish_attribute(tag):
     """
     tag_data = tag.metadata()
     # get data to the publish attribute
-    value = tag_data.value("tag.publish")
-    # return value converted to bool value. Atring is stored in tag.
-    return ast.literal_eval(value)
+    return json.loads(tag_data.get("tag.json_metadata"))["publish"]
 
 
 def sync_avalon_data_to_workfile():

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -557,7 +557,19 @@ def get_trackitem_openpype_data(track_item):
         key = k.replace("tag.", "")
 
         try:
-            value = ast.literal_eval(v)
+            # capture exceptions which are related to strings only
+            if re.match(r"^[\d]+$", v):
+                value = int(v)
+            elif re.match(r"^True$", v):
+                value = True
+            elif re.match(r"^False$", v):
+                value = False
+            elif re.match(r"^None$", v):
+                value = None
+            elif re.match(r"^[\w\d_]+$", v):
+                value = v
+            else:
+                value = ast.literal_eval(v)
         except (ValueError, SyntaxError):
             value = v
 

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -1270,8 +1270,8 @@ def sync_clip_name_to_data_asset(track_items_list):
             continue
 
         # fix data if wrong name
-        if data["asset"] != ti_name:
-            data["asset"] = ti_name
+        if data["asset_name"] != ti_name:
+            data["asset_name"] = ti_name
             # remove the original tag
             tag = get_trackitem_openpype_tag(track_item)
             track_item.removeTag(tag)

--- a/client/ayon_hiero/api/otio/hiero_export.py
+++ b/client/ayon_hiero/api/otio/hiero_export.py
@@ -239,13 +239,7 @@ def create_otio_markers(otio_item, item):
         for key, value in tag.metadata().dict().items():
             _key = key.replace("tag.", "")
 
-            try:
-                # capture exceptions which are related to strings only
-                _value = ast.literal_eval(value)
-            except (ValueError, SyntaxError):
-                _value = value
-
-            metadata.update({_key: _value})
+            metadata.update({_key: value})
 
         # Store the source item for future import assignment
         metadata['hiero_source_type'] = item.__class__.__name__

--- a/client/ayon_hiero/api/tags.py
+++ b/client/ayon_hiero/api/tags.py
@@ -86,18 +86,10 @@ def update_tag(tag, data):
     # get metadata key from data
     data_mtd = data.get("metadata", {})
 
-    # set all data metadata to tag metadata
-    for _k, _v in data_mtd.items():
-        value = str(_v)
-        if isinstance(_v, dict):
-            value = json.dumps(_v)
-
-        # set the value
-        mtd.setValue(
-            "tag.{}".format(str(_k)),
-            value
-        )
-
+    mtd.setValue(
+        f"tag.json_metadata",
+        json.dumps(data_mtd)
+    )
     # set note description of tag
     tag.setNote(str(data["note"]))
     return tag

--- a/client/ayon_hiero/plugins/publish/collect_frame_tag_instances.py
+++ b/client/ayon_hiero/plugins/publish/collect_frame_tag_instances.py
@@ -1,7 +1,7 @@
 from pprint import pformat
+import json
 import re
 import ast
-import json
 
 import pyblish.api
 
@@ -37,10 +37,14 @@ class CollectFrameTagInstances(pyblish.api.ContextPlugin):
         data = {}
 
         # get tag metadata attribute
-        tag_data = tag.metadata()
+        tag_data = dict(tag.metadata())
+
+        if tag_data.get("tag.json_metadata"):
+            return json.loads(tag_data.get("tag.json_metadata"))
 
         # convert tag metadata to normal keys names and values to correct types
-        for k, v in dict(tag_data).items():
+        # legacy
+        for k, v in tag_data.items():
             key = k.replace("tag.", "")
 
             try:

--- a/client/ayon_hiero/plugins/publish/precollect_instances.py
+++ b/client/ayon_hiero/plugins/publish/precollect_instances.py
@@ -10,6 +10,7 @@ import hiero
 # # developer reload modules
 from pprint import pformat
 
+from ayon_hiero.api import get_publish_attribute
 
 class PrecollectInstances(pyblish.api.ContextPlugin):
     """Collect all Track items selection."""

--- a/client/ayon_hiero/plugins/publish/precollect_instances.py
+++ b/client/ayon_hiero/plugins/publish/precollect_instances.py
@@ -10,7 +10,6 @@ import hiero
 # # developer reload modules
 from pprint import pformat
 
-from ayon_hiero.api import get_publish_attribute
 
 class PrecollectInstances(pyblish.api.ContextPlugin):
     """Collect all Track items selection."""


### PR DESCRIPTION
## Changelog Description
Replaced usage of separate tags and type conversion with `ast` to storing everything in single `tag.json_metadata` which provides typing out of the box.


## Additional info
Warnings or regexes caused unnecessary slowdown each saving or publishing with large amount of tracks in a workfile.
Fixed additional issue with key value of `asset`.

Unrelated issue, but causing some slowdown, is default DEBUG level in Pyblish plugins. It should be tied to `debug` command line argument, but it is not (imho).


## Testing notes:

1. publish or save Hiero workfile with created AYON publish instances.
2. console output shouldn't contain anything like:
```
*** WRN: >>> { ayon_hiero.api.lib }: [  invalid decimal literal (<unknown>, line 1)  ] *** WRN: >>> { ayon_hiero.api.lib }: [  malformed node or string on line 1: <ast.Attribute object at 0x0000021367352DD0>  ] *** WRN: >>> { ayon_hiero.api.lib }: [  invalid syntax (<unknown>, line 1)  ]
```
