### PR TITLE
Chore: Ruff linter fixes

### DIFF
--- a/client/ayon_hiero/api/pipeline.py
+++ b/client/ayon_hiero/api/pipeline.py
@@ -131,7 +131,7 @@ def ls():
 
     # append all video tracks
     for track in (lib.get_current_sequence() or []):
-        if type(track) != hiero.core.VideoTrack:
+        if type(track) is not hiero.core.VideoTrack:
             continue
         all_items.append(track)
 
@@ -189,7 +189,7 @@ def parse_container(item, validate=True):
         return container
 
     # convert tag metadata to normal keys names
-    if type(item) == hiero.core.VideoTrack:
+    if type(item) is hiero.core.VideoTrack:
         return_list = []
         _data = lib.get_track_openpype_data(item)
 
@@ -231,7 +231,7 @@ def update_container(item, data=None):
     data = data or {}
     data = deepcopy(data)
 
-    if type(item) == hiero.core.VideoTrack:
+    if type(item) is hiero.core.VideoTrack:
         # form object data for test
         object_name = data["objectName"]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -38,7 +38,7 @@ indent-width = 4
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "W"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
## Changelog Description
Fixed errors related to ruff linting and added warnings to ruff config.

## Additional info
The `is` comparison should be maybe replaced with `isinstance` check, but I can't validate if that would work so I just changed it to `is` comparison.

## Testing notes:
1. All should work.
