### PR TITLE
Fix Hiero to Nuke colorspace colorspace publish bug.

### DIFF
--- a/client/ayon_hiero/plugins/publish/precollect_instances.py
+++ b/client/ayon_hiero/plugins/publish/precollect_instances.py
@@ -158,11 +158,8 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
             instance = context.create_instance(**data)
 
             # add colorspace data
-            instance.data.update({
-                "versionData": {
-                    "colorSpace": track_item.sourceMediaColourTransform(),
-                }
-            })
+            version_data = instance.data.setdefault("versionData", {})
+            version_data["colorSpace"] = track_item.sourceMediaColourTransform()
 
             # create shot instance for shot attributes create/update
             self.create_shot_instance(context, **data)


### PR DESCRIPTION
## Changelog Description
 resolve #10 
This small change ensures that the colorspace data is set properly at publish time where the importer is expecting it in order to restore the OCIO colorspace that was selected initially.


## Additional info
More detail about the investigation steps and fixes on the issue link:  #10 .
This fix is also reported in #14 


## Testing notes:

0. Ensure that `OCIO Colorspace` settings is enabled for your project
1. Open `Hiero` and create a `Sequence` with a media
2. Manually edit the colorspace of the media in `Hiero`
3. Publish the resulting `Sequence` as new `Shot` and `Plate` products
4. Load the resulting `Plate` in `Nuke` through AYON Loader
5. Ensure the edited colorspace is propagated and comes by default at load in Nuke

in Hiero:
![colorspace_in_hiero](https://github.com/user-attachments/assets/7a2eef1c-db0c-48dd-b192-0cef4101a207)

in Nuke:
![colorspace_in_nuke](https://github.com/user-attachments/assets/67e8e4de-716b-4dfa-858f-7c5fed8cd788)


