### PR TITLE
Update metadata keys and add colorspace data

### DIFF
--- a/client/ayon_hiero/api/otio/hiero_export.py
+++ b/client/ayon_hiero/api/otio/hiero_export.py
@@ -152,10 +152,10 @@ def create_otio_reference(clip):
 
     # add resolution metadata
     metadata.update({
-        "openpype.source.colourtransform": clip.sourceMediaColourTransform(),
-        "openpype.source.width": int(media_source.width()),
-        "openpype.source.height": int(media_source.height()),
-        "openpype.source.pixelAspect": float(media_source.pixelAspect())
+        "ayon.source.colorspace": clip.sourceMediaColourTransform(),
+        "ayon.source.width": int(media_source.width()),
+        "ayon.source.height": int(media_source.height()),
+        "ayon.source.pixelAspect": float(media_source.pixelAspect())
     })
 
     otio_ex_ref_item = None
@@ -369,17 +369,6 @@ def add_otio_metadata(otio_item, media_source, **kwargs):
 
 
 def create_otio_timeline():
-
-    def set_prev_item(itemindex, track_item):
-        # Add Gap if needed
-        if itemindex == 0:
-            # if it is first track item at track then add
-            # it to previous item
-            return track_item
-
-        else:
-            # get previous item
-            return track_item.parent().items()[itemindex - 1]
 
     # get current timeline
     CTX.timeline = hiero.ui.activeSequence()

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -25,5 +25,11 @@ class CollectPlate(pyblish.api.InstancePlugin):
         )
 
         track_item = instance.data["item"]
+        clip_colorspace = track_item.sourceMediaColourTransform()
+
+        # add colorspace data to versionData
         version_data = instance.data.setdefault("versionData", {})
-        version_data["colorSpace"] = track_item.sourceMediaColourTransform()
+        version_data["colorSpace"] = clip_colorspace
+
+        # add colorspace data to instance
+        instance.data["colorspace"] = clip_colorspace

--- a/client/ayon_hiero/plugins/publish/extract_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/extract_clip_effects.py
@@ -65,7 +65,7 @@ class ExtractClipEffects(publish.Extractor):
 
         # add to data of representation
         version_data.update({
-            "colorspace": item.sourceMediaColourTransform(),
+            "colorSpace": item.sourceMediaColourTransform(),
             "colorspaceScript": instance.context.data["colorspace"],
             "families": [product_type, "plate"],
             # TODO find out if 'subset' is needed (and 'productName')


### PR DESCRIPTION
# Changelog description

- Colorspace data to instances and versionData. 
- Remove redundant function set_prev_item from create_otio_timeline. 
- Fix key naming for colorspace in ExtractClipEffects plugin.


## Testing steps
- open your testing project in Hiero
- publish clips and notice that log details from `Collect OTIO Subset Resources` plugin is having at new representations data key `colorspaceData` with correct  **colorspace** key with value the same as it is set at your hiero clip colorspace attribute. 
