### PR TITLE
Publishing reviewable attributes enhancements

### DIFF
--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -689,7 +689,9 @@ class PublishClip:
         # publish settings
         "audio", "sourceResolution",
         # shot attributes
-        "workfileFrameStart", "handleStart", "handleEnd"
+        "workfileFrameStart", "handleStart", "handleEnd",
+        # instance attributes data
+        "reviewableTrack",
     }
 
     def __init__(

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -16,6 +16,30 @@ class CollectPlate(pyblish.api.InstancePlugin):
         """
         instance.data["families"].append("clip")
 
+        # solve reviewable options
+        review_switch = instance.data["creator_attributes"].get("review")
+        review_track_name = instance.data["creator_attributes"].get(
+            "reviewableTrack")
+
+        if review_switch is True:
+            instance.data["families"].append("review")
+            instance.data.pop("reviewTrack")
+
+        if (
+            review_track_name != "< none >"
+            and review_switch is not True
+        ):
+            instance.data["reviewTrack"] = review_track_name
+
+        elif (
+            review_track_name == "< none >"
+            # the reviewTrack key is set to None if '< none >' is selected
+            # in creator plugin
+            and instance.data.get("reviewTrack", False) is None
+        ):
+            # lets just remove it if it is not relevant
+            instance.data.pop("reviewTrack")
+
         # Retrieve instance data from parent instance shot instance.
         parent_instance_id = instance.data["parent_instance_id"]
         edit_shared_data = instance.context.data["editorialSharedData"]


### PR DESCRIPTION
## Changelog Description
Instance attributes for reviewable items with interactivity involve two key elements for proper distribution: setting either a reviewable track or simply flagging for later extraction by transcoding tools. Either of the option will interact with the other.

## Additional info
closes #21

## Testing notes:
1. Open the Hiero testing project and create a clip with the reviewable track selected.
2. After instances are created, set the reviewable track to `<none>`. You'll see a new attribute for the **review** switch.
3. Use the switch to activate the review. Notice that the option to select a 'reviewable track' will disappear.