### PR TITLE
Fixing distribution of otioClip attribute to plates

### DIFF
--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -176,6 +176,9 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
         self.create_context.add_value_changed_callback(self._on_value_change)
 
     def _on_value_change(self, event):
+        if self.product_type != "plate":
+            return
+
         for item in event["changes"]:
             instance = item["instance"]
             if (
@@ -219,7 +222,7 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
                 disabled=True,
             )
         ]
-        if self.product_type in ("plate", "audio"):
+        if self.product_type == "plate":
             # Review track visibility
             current_review = instance.creator_attributes.get("review", False)
 
@@ -274,6 +277,39 @@ class EditorialAudioInstanceCreator(_HieroInstanceClipCreatorBase):
     identifier = "io.ayon.creators.hiero.audio"
     product_type = "audio"
     label = "Editorial Audio"
+
+    def get_product_name(
+        self,
+        project_name,
+        folder_entity,
+        task_entity,
+        variant,
+        host_name=None,
+        instance=None,
+        project_entity=None):
+        return f"{self.product_type}Main"
+
+    def get_attr_defs_for_instance(self, instance):
+
+        instance_attributes = [
+            TextDef(
+                "parentInstance",
+                label="Linked to",
+                disabled=True,
+            )
+        ]
+
+        instance_attributes.extend(
+            [
+                BoolDef(
+                    "review",
+                    label="Review",
+                    tooltip="Switch to reviewable instance",
+                    default=False,
+                ),
+            ]
+        )
+        return instance_attributes
 
 
 class CreateShotClip(plugin.HieroCreator):
@@ -593,6 +629,8 @@ OTIO file.
             for creator_id in enabled_creators:
                 creator = self.create_context.creators[creator_id]
                 sub_instance_data = copy.deepcopy(_instance_data)
+                creator_attributes = sub_instance_data.setdefault(
+                    "creator_attributes", {})
                 shot_folder_path = sub_instance_data["folderPath"]
 
                 # Shot creation
@@ -613,40 +651,60 @@ OTIO file.
                                 "handleStart": sub_instance_data["handleStart"],
                                 "handleEnd": sub_instance_data["handleEnd"],
                                 "frameStart": workfileFrameStart,
-                                "frameEnd": (workfileFrameStart + track_item_duration),
+                                "frameEnd": (
+                                    workfileFrameStart + track_item_duration),
                                 "clipIn": track_item.timelineIn(),
                                 "clipOut": track_item.timelineOut(),
                                 "clipDuration": track_item_duration,
                                 "sourceIn": track_item.sourceIn(),
                                 "sourceOut": track_item.sourceOut(),
                             },
-                            "label": (f"{sub_instance_data['folderPath']} shotMain"),
+                            "label": (
+                                f"{sub_instance_data['folderPath']} shotMain"),
                         }
                     )
 
                 # Plate, Audio
                 # insert parent instance data to allow
                 # metadata recollection as publish time.
-                else:
+                elif creator_id == plate_creator_id:
                     parenting_data = shot_instances[shot_creator_id]
                     sub_instance_data.update({
                         "parent_instance_id": parenting_data["instance_id"],
                         "label": (
                             f"{sub_instance_data['folderPath']} "
                             f"{sub_instance_data['productName']}"
-                        ),
-                        "creator_attributes": {
-                            "parentInstance": parenting_data["label"],
-                        }
+                        )
                     })
-
-                    # add reviewable source to plate if shot has it
+                    creator_attributes["parentInstance"] = parenting_data[
+                        "label"]
                     if sub_instance_data.get("reviewableSource"):
-                        sub_instance_data["creator_attributes"].update({
+                        creator_attributes.update({
+                            "review": True,
                             "reviewableSource": sub_instance_data[
                                 "reviewableSource"],
-                            "review": True,
                         })
+
+                elif creator_id == audio_creator_id:
+                    sub_instance_data["variant"] = "main"
+                    sub_instance_data["productType"] = "audio"
+                    sub_instance_data["productName"] = "audioMain"
+
+                    parenting_data = shot_instances[shot_creator_id]
+                    sub_instance_data.update(
+                        {
+                            "parent_instance_id": parenting_data["instance_id"],
+                            "label": (
+                                f"{sub_instance_data['folderPath']} "
+                                f"{sub_instance_data['productName']}"
+                            )
+                        }
+                    )
+                    creator_attributes["parentInstance"] = parenting_data[
+                        "label"]
+
+                    if sub_instance_data.get("reviewableSource"):
+                        creator_attributes["review"] = True
 
                 instance = creator.create(sub_instance_data, None)
                 instance.transient_data["track_item"] = track_item

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -219,7 +219,7 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
                 disabled=True,
             )
         ]
-        if self.product_type == "plate":
+        if self.product_type in ("plate", "audio"):
             # Review track visibility
             current_review = instance.creator_attributes.get("review", False)
 
@@ -523,11 +523,15 @@ OTIO file.
 
         sorted_selected_track_items.extend(unsorted_selected_track_items)
 
+        shot_creator_id = "io.ayon.creators.hiero.shot"
+        audio_creator_id = "io.ayon.creators.hiero.audio"
+        plate_creator_id = "io.ayon.creators.hiero.plate"
+
         # detect enabled creators for review, plate and audio
         all_creators = {
-            "io.ayon.creators.hiero.shot": True,
-            "io.ayon.creators.hiero.plate": True,
-            "io.ayon.creators.hiero.audio": pre_create_data.get("export_audio", False),
+            shot_creator_id: True,
+            plate_creator_id: True,
+            audio_creator_id: True,
         }
 
         instances = []
@@ -572,9 +576,16 @@ OTIO file.
             shot_folder_path = _instance_data["folderPath"]
             shot_instances = self.shot_instances.setdefault(
                 shot_folder_path, {})
-            shot_creator_id = "io.ayon.creators.hiero.shot"
-            all_creators["io.ayon.creators.hiero.shot"] = _instance_data.get(
+
+            # desable shot creator if heroTrack is not enabled
+            all_creators[shot_creator_id] = _instance_data.get(
                 "heroTrack", False)
+            # desable audio creator if audio is not enabled
+            all_creators[audio_creator_id] = (
+                _instance_data.get("heroTrack", False) and
+                pre_create_data.get("export_audio", False)
+            )
+
             enabled_creators = tuple(
                 cre for cre, enabled in all_creators.items() if enabled
             )

--- a/client/ayon_hiero/plugins/publish/collect_audio.py
+++ b/client/ayon_hiero/plugins/publish/collect_audio.py
@@ -1,5 +1,8 @@
 import pyblish
 
+from ayon_core.pipeline import PublishError
+from ayon_hiero.api.otio import utils
+
 
 class CollectAudio(pyblish.api.InstancePlugin):
     """Collect new audio."""
@@ -17,9 +20,21 @@ class CollectAudio(pyblish.api.InstancePlugin):
         # Retrieve instance data from parent instance shot instance.
         parent_instance_id = instance.data["parent_instance_id"]
         edit_shared_data = instance.context.data["editorialSharedData"]
-        instance.data.update(
-            edit_shared_data[parent_instance_id]
+        shot_instance_data = edit_shared_data[parent_instance_id]
+        instance.data.update(shot_instance_data)
+
+        # Adjust instance data from parent otio timeline.
+        otio_timeline = instance.context.data["otioTimeline"]
+        # Clip index has to be taken form hero shot data
+        # audio could be shorter but we need to get full length
+        otio_clip, _ = utils.get_marker_from_clip_index(
+            otio_timeline, shot_instance_data["clip_index"]
         )
+        if not otio_clip:
+            raise PublishError(
+                f"Could not retrieve otioClip for shot {instance}")
+
+        instance.data["otioClip"] = otio_clip
 
         if instance.data.get("reviewTrack") is not None:
             instance.data["reviewAudio"] = True

--- a/client/ayon_hiero/plugins/publish/collect_audio.py
+++ b/client/ayon_hiero/plugins/publish/collect_audio.py
@@ -28,7 +28,7 @@ class CollectAudio(pyblish.api.InstancePlugin):
         # Clip index has to be taken form hero shot data
         # audio could be shorter but we need to get full length
         otio_clip, _ = utils.get_marker_from_clip_index(
-            otio_timeline, shot_instance_data["clip_index"]
+            otio_timeline, shot_instance_data["shot_clip_index"]
         )
         if not otio_clip:
             raise PublishError(
@@ -36,11 +36,14 @@ class CollectAudio(pyblish.api.InstancePlugin):
 
         instance.data["otioClip"] = otio_clip
 
-        if instance.data.get("reviewTrack") is not None:
-            instance.data["reviewAudio"] = True
-            instance.data.pop("reviewTrack")
+        # solve reviewable options
+        review_switch = instance.data["creator_attributes"].get("review")
 
-        clip_src = instance.data["otioClip"].source_range
+        if review_switch is True:
+            instance.data["reviewAudio"] = True
+            instance.data.pop("review", None)
+
+        clip_src = otio_clip.source_range
         clip_src_in = clip_src.start_time.to_frames()
         clip_src_out = clip_src_in + clip_src.duration.to_frames()
         instance.data.update({

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -1,4 +1,5 @@
 import pyblish
+from ayon_hiero.api.otio import utils
 
 
 class CollectPlate(pyblish.api.InstancePlugin):
@@ -15,6 +16,17 @@ class CollectPlate(pyblish.api.InstancePlugin):
             instance (pyblish.Instance): The shot instance to update.
         """
         instance.data["families"].append("clip")
+
+        # Adjust instance data from parent otio timeline.
+        otio_timeline = instance.context.data["otioTimeline"]
+        otio_clip, _ = utils.get_marker_from_clip_index(
+            otio_timeline, instance.data["clip_index"]
+        )
+        if not otio_clip:
+            raise RuntimeError(
+                f"Could not retrieve otioClip for shot {instance}")
+
+        instance.data["otioClip"] = otio_clip
 
         # solve reviewable options
         review_switch = instance.data["creator_attributes"].get(

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -1,4 +1,6 @@
 import pyblish
+
+from ayon_core.pipeline import PublishError
 from ayon_hiero.api.otio import utils
 
 
@@ -23,7 +25,7 @@ class CollectPlate(pyblish.api.InstancePlugin):
             otio_timeline, instance.data["clip_index"]
         )
         if not otio_clip:
-            raise RuntimeError(
+            raise PublishError(
                 f"Could not retrieve otioClip for shot {instance}")
 
         instance.data["otioClip"] = otio_clip

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -1,6 +1,7 @@
 import json
 import pyblish
 
+from ayon_core.pipeline import PublishError
 from ayon_hiero.api import lib
 from ayon_hiero.api.otio import utils
 
@@ -77,7 +78,8 @@ class CollectShot(pyblish.api.InstancePlugin):
             otio_timeline, instance.data["clip_index"]
         )
         if not otio_clip:
-            raise RuntimeError("Could not retrieve otioClip for shot %r", instance)
+            raise PublishError(
+                f"Could not retrieve otioClip for shot {instance}")
 
         # Compute fps from creator attribute.
         if instance.data['creator_attributes']["fps"] == "from_selection":

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -60,10 +60,15 @@ class CollectShot(pyblish.api.InstancePlugin):
         if not context.data.get("editorialSharedData"):
             context.data["editorialSharedData"] = {}
 
-        context.data["editorialSharedData"][instance_id] = {
+        edit_shared_data = context.data["editorialSharedData"].setdefault(
+            instance_id, {}
+        )
+        edit_shared_data.update({
             key: value for key, value in instance.data.items()
             if key in cls.SHARED_KEYS
-        }
+        })
+        # also add `shot_clip_index` to shared data for audio instance
+        edit_shared_data["shot_clip_index"] = instance.data["clip_index"]
 
     def process(self, instance):
         """

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -22,7 +22,6 @@ class CollectShot(pyblish.api.InstancePlugin):
         "handleStart",
         "handleEnd",
         "item",
-        "otioClip",
         "resolutionWidth",
         "resolutionHeight",
         "pixelAspect",


### PR DESCRIPTION
## Changelog Description
Vertical aligned shot resources are distributed correctly now. 

## Testing notes:
1. Create timeline in Hiero with vertically aligned shots in multiple tracks. Make sure media resources for each clip is different.
2. Rename tracks to hold some unique names
3. select shots which are vertically aligned
4. go to AYON menu and Create
5. enamble vertical sync
6. Select hero track 
7. Hit Create and then Publish.
8. notice the integrated files and make sure plate version is having correct representation files. 

Resolves #30 