### PR TITLE
AY-7242_Fix clip_media review source from Hiero.

### DIFF
--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -44,7 +44,7 @@ class CollectPlate(pyblish.api.InstancePlugin):
 
                 # Retrieve source clip media from otio clip.
                 # image sequence
-                if hasattr(otio_clip.media_reference, "target_url_base"):
+                if hasattr(otio_clip.media_reference, "target_url_for_image_number"):
                     file_url = otio_clip.media_reference.target_url_for_image_number(0)
                     sequence_length = (
                         otio_clip.media_reference.end_frame()

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -1,4 +1,3 @@
-import os
 import pyblish
 
 from ayon_core.pipeline import PublishError

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -41,38 +41,6 @@ class CollectPlate(pyblish.api.InstancePlugin):
             if reviewable_source == "clip_media":
                 instance.data["families"].append("review")
                 instance.data.pop("reviewTrack", None)
-
-                # Retrieve source clip media from otio clip.
-                # image sequence
-                if hasattr(otio_clip.media_reference, "target_url_for_image_number"):
-                    file_url = otio_clip.media_reference.target_url_for_image_number(0)
-                    sequence_length = (
-                        otio_clip.media_reference.end_frame()
-                        - otio_clip.media_reference.start_frame
-                    )
-                    file_names = [
-                        os.path.basename(
-                            otio_clip.media_reference.target_url_for_image_number(frame)
-                        )
-                        for frame in range(0, sequence_length)
-                    ]
-
-                # movie
-                else:
-                    file_url = otio_clip.media_reference.target_url
-                    file_names = os.path.basename(file_url)
-
-                _, ext = os.path.splitext(file_url)
-
-                repre = {
-                    "name": ext[1:],
-                    "ext": ext[1:],
-                    "files": file_names,
-                    "stagingDir": os.path.dirname(file_url),
-                    "tags": ["review", "delete"]
-                }
-                instance.data["representations"].append(repre)
-
             else:
                 instance.data["reviewTrack"] = reviewable_source
 


### PR DESCRIPTION
## Changelog Description

When testing Flame and Hiero we realized that the `[Clip media]` option of `Reviewable Source` did not work properly.
Here is the bug fix for Hiero.

## Additional review information
This changes needs to be tested alongside https://github.com/ynput/ayon-core/pull/1036

## Testing notes:
1. Open Hiero and create instance(s) through the `Create Publishable Clip`
2. Set the review source media to `[Clip media]`
![image](https://github.com/user-attachments/assets/bb472e65-c905-42b0-97e8-f82bac164bb8)
3. Publish and ensure that the resulting review product is created from the original clip media entire range (untrimmed)

AY-7242