### PR TITLE
More consolidations on Hiero OTIO exporter

### DIFF
--- a/client/ayon_hiero/api/otio/hiero_export.py
+++ b/client/ayon_hiero/api/otio/hiero_export.py
@@ -267,10 +267,15 @@ def create_otio_clip(track_item):
 
     media_reference = create_otio_reference(clip)
     available_start = media_reference.available_range.start_time
-    conformed_start_value = available_start.value_rescaled_to(fps)
+    source_in_offset = otio.opentime.RationalTime(
+        source_in,
+        available_start.rate
+    )
+    src_in = available_start + source_in_offset
+    conformed_src_in = src_in.rescaled_to(fps)
 
     source_range = create_otio_time_range(
-        conformed_start_value + source_in,
+        conformed_src_in.value,  # no rounding to preserve accuracy
         duration,
         fps
     )


### PR DESCRIPTION
## Changelog Description
help resolve https://github.com/ynput/ayon-hiero/issues/29

* [X] We were loosing some accuracy on OTIO export for source range start_time, this was causing rounding issues with longest frame range.

## Additional review information

## Testing notes:
1. Create a clip in Hiero with a long frame range (e.g. `start_frame > 900,000` at `24.0 fps`)
2. Drag and drop on a `23.976` sequence while preserving clip duration
3. Trim clip to specific frame input output
4. Export sequence to OTIO and ensure source range of the clip match input frame when rescaled back to `24.0 fps`
