### PR TITLE
Fix clip attribute value for frame rate options

### DIFF
--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -18,7 +18,7 @@ CLIP_ATTR_DEFS = [
         "fps",
         items=[
             {"value": "from_selection", "label": "From selection"},
-            {"value": 23.997, "label": "23.976"},
+            {"value": 23.976, "label": "23.976"},
             {"value": 24, "label": "24"},
             {"value": 25, "label": "25"},
             {"value": 29.97, "label": "29.97"},


### PR DESCRIPTION
Updated the frame rate option to correctly reflect 23.976 instead of 23.997 in the clip attributes list.
