### PR TITLE
Support optional state of `Version-up Workfile` plug-in

### DIFF
--- a/client/ayon_hiero/plugins/publish/integrate_version_up_workfile.py
+++ b/client/ayon_hiero/plugins/publish/integrate_version_up_workfile.py
@@ -1,9 +1,13 @@
 from pyblish import api
 
 from ayon_core.lib import version_up
+from ayon_core.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+)
 
 
-class IntegrateVersionUpWorkfile(api.ContextPlugin):
+class IntegrateVersionUpWorkfile(api.ContextPlugin,
+                                 OptionalPyblishPluginMixin):
     """Save as new workfile version"""
 
     order = api.IntegratorOrder + 10.1
@@ -14,6 +18,10 @@ class IntegrateVersionUpWorkfile(api.ContextPlugin):
     active = True
 
     def process(self, context):
+        if not self.is_active(context.data):
+            self.log.debug("Project workfile version up was skipped")
+            return
+
         project = context.data["activeProject"]
         path = context.data.get("currentFile")
         new_path = version_up(path)


### PR DESCRIPTION
## Changelog Description

Support optional state of `Version-up Workfile` plug-in. It now correctly exposes optional state the UI.

## Additional review information

Similar change as @jrsndl described [here](https://github.com/ynput/ayon-hiero/issues/19#issuecomment-2606567736).

Even though this change is mentioned in #19 it doesn't necessarily fix the full issue because it doesn't change how the publish may still remain linked to the workfile version - it just allows disabling the workfile getting incremented on a publish.

## Testing notes:

1. Increment workfile version up is now optional
