### PR TITLE
Add creator attributes to be able to disable effect discovery and publishing for clip from plate instances.

### DIFF
--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -249,6 +249,12 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
                         ),
                         disabled=not current_review,
                     ),
+                    BoolDef(
+                        "publish_effects",
+                        label="Publish clip effects",
+                        tooltip="Discover and publish clip effects",
+                        default=True,
+                    ),
                 ]
             )
         return instance_attributes

--- a/client/ayon_hiero/plugins/publish/collect_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/collect_clip_effects.py
@@ -20,6 +20,14 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
         review = instance.data.get("review")
         review_track_index = instance.context.data.get("reviewTrackIndex")
         item = instance.data["item"]
+        product_name = instance.data.get("productName")
+
+        if not instance.data["creator_attributes"]["publish_effects"]:
+            self.log.debug(
+                "Effects collection/publish is disabled for %s",
+                product_name,
+            )
+            return
 
         if "audio" in instance.data["productType"]:
             return
@@ -64,7 +72,6 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
         if not effects:
             return
 
-        product_name = instance.data.get("productName")
         effects.update({"assignTo": product_name})
 
         product_name_split = re.findall(r'[A-Z][^A-Z]*', product_name)


### PR DESCRIPTION
## Changelog Description
resolve: https://github.com/ynput/ayon-hiero/issues/26

Initial idea was to be able to collect and create instances for each effects within the creators, unfortnately this is proven to be more difficult then expected to sync the instances with the sequence effects (more detail on the ticket).

This PR implement a `Publish clip effects` trigger to enable and disable the effect publishing for a specific plate clip.
![image](https://github.com/user-attachments/assets/7447a38f-056d-4643-8165-1ecf266a054d)


## Additional review information

## Testing notes:
1. Within Hiero, create a publish plate clip with associated effects (TimeWarp, Text...)
2. Disable the `Publish clip effects` toggle from the creator attributes.
3. Ensure none of the associated effects get published as a result