### PR TITLE
AY-7460 Fix clip source resolution detection from timeline

### DIFF
--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -118,7 +118,7 @@ class CollectShot(pyblish.api.InstancePlugin):
 
         # Retrieve clip from active_timeline
         if overwrite_clip_metadata:
-            source_clip = item.source()
+            source_clip = track_item.source()
             item_format = source_clip.format()
 
         # Get resolution from active timeline


### PR DESCRIPTION
## Changelog Description

This issue was reported by one of our clients.
Source clip resolution detection was unreliable.

## Additional review information


## Testing notes:
1. Create a shot/clip hierarchy enabling the `source resolution` option
![image](https://github.com/user-attachments/assets/580e5931-b521-4e4a-b923-5c73ecb9a954)

2. Publish the shot and ensure proper resolution is detected

closes #48 