### PR TITLE
Improve create_shot_clip code readability.

### DIFF
--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -655,8 +655,6 @@ class PublishClip:
     Returns:
         hiero.core.TrackItem: hiero track item object with AYON tag
     """
-    vertical_clip_match = {}
-    vertical_clip_used = {}
     tag_data = {}
 
     types = {
@@ -696,17 +694,17 @@ class PublishClip:
         "reviewableSource",
     }
 
-    @classmethod
-    def restore_all_caches(cls):
-        cls.vertical_clip_match = {}
-        cls.vertical_clip_used = {}
-
     def __init__(
             self,
             track_item,
+            vertical_clip_match,
+            vertical_clip_used,
             pre_create_data=None,
             data=None,
             rename_index=0):
+
+        self.vertical_clip_match = vertical_clip_match
+        self.vertical_clip_used = vertical_clip_used
 
         self.rename_index = rename_index
 
@@ -812,6 +810,7 @@ class PublishClip:
         self.product_type = get("productType") or self.product_type_default
         self.vertical_sync = get("vSyncOn") or self.vertical_sync_default
         self.driving_layer = get("vSyncTrack") or self.driving_layer_default
+        self.driving_layer = self.driving_layer.replace(" ", "_")
         self.review_source = (
             get("reviewableSource") or self.review_source_default)
         self.audio = get("audio") or False

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -224,18 +224,23 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
                 disabled=True,
             )
         ]
+
+        if self.product_type in ("audio", "plate"):
+            instance_attributes.append(
+                BoolDef(
+                    "review",
+                    label="Review",
+                    tooltip="Switch to reviewable instance",
+                    default=False,
+                )
+            )
+
         if self.product_type == "plate":
             # Review track visibility
             current_review = instance.creator_attributes.get("review", False)
 
             instance_attributes.extend(
                 [
-                    BoolDef(
-                        "review",
-                        label="Review",
-                        tooltip="Switch to reviewable instance",
-                        default=False,
-                    ),
                     EnumDef(
                         "reviewableSource",
                         label="Reviewable Source",
@@ -268,17 +273,6 @@ class EditorialPlateInstanceCreator(_HieroInstanceClipCreatorBase):
     product_type = "plate"
     label = "Editorial Plate"
 
-    def create(self, instance_data, _):
-        """Return a new CreateInstance for new shot from Resolve.
-
-        Args:
-            instance_data (dict): global data from original instance
-
-        Return:
-            CreatedInstance: The created instance object for the new shot.
-        """
-        return super().create(instance_data, None)
-
 
 class EditorialAudioInstanceCreator(_HieroInstanceClipCreatorBase):
     """Audio product type creator class"""
@@ -296,28 +290,6 @@ class EditorialAudioInstanceCreator(_HieroInstanceClipCreatorBase):
         instance=None,
         project_entity=None):
         return f"{self.product_type}Main"
-
-    def get_attr_defs_for_instance(self, instance):
-
-        instance_attributes = [
-            TextDef(
-                "parentInstance",
-                label="Linked to",
-                disabled=True,
-            )
-        ]
-
-        instance_attributes.extend(
-            [
-                BoolDef(
-                    "review",
-                    label="Review",
-                    tooltip="Switch to reviewable instance",
-                    default=False,
-                ),
-            ]
-        )
-        return instance_attributes
 
 
 class CreateShotClip(plugin.HieroCreator):
@@ -652,23 +624,25 @@ OTIO file.
                             "variant": "main",
                             "productType": "shot",
                             "productName": "shotMain",
-                            "creator_attributes": {
-                                "workfileFrameStart": sub_instance_data[
-                                    "workfileFrameStart"
-                                ],
-                                "handleStart": sub_instance_data["handleStart"],
-                                "handleEnd": sub_instance_data["handleEnd"],
-                                "frameStart": workfileFrameStart,
-                                "frameEnd": (
-                                    workfileFrameStart + track_item_duration),
-                                "clipIn": track_item.timelineIn(),
-                                "clipOut": track_item.timelineOut(),
-                                "clipDuration": track_item_duration,
-                                "sourceIn": track_item.sourceIn(),
-                                "sourceOut": track_item.sourceOut(),
-                            },
                             "label": (
                                 f"{sub_instance_data['folderPath']} shotMain"),
+                        }
+                    )
+                    creator_attributes.update(
+                        {
+                            "workfileFrameStart": sub_instance_data[
+                                "workfileFrameStart"
+                            ],
+                            "handleStart": sub_instance_data["handleStart"],
+                            "handleEnd": sub_instance_data["handleEnd"],
+                            "frameStart": workfileFrameStart,
+                            "frameEnd": (
+                                workfileFrameStart + track_item_duration),
+                            "clipIn": track_item.timelineIn(),
+                            "clipOut": track_item.timelineOut(),
+                            "clipDuration": track_item_duration,
+                            "sourceIn": track_item.sourceIn(),
+                            "sourceOut": track_item.sourceOut(),
                         }
                     )
 

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -280,17 +280,6 @@ class EditorialAudioInstanceCreator(_HieroInstanceClipCreatorBase):
     product_type = "audio"
     label = "Editorial Audio"
 
-    def get_product_name(
-        self,
-        project_name,
-        folder_entity,
-        task_entity,
-        variant,
-        host_name=None,
-        instance=None,
-        project_entity=None):
-        return f"{self.product_type}Main"
-
 
 class CreateShotClip(plugin.HieroCreator):
     """Publishable clip"""
@@ -307,8 +296,6 @@ or updating already created from Hiero. Publishing will create
 OTIO file.
 """
     create_allow_thumbnail = False
-
-    shot_instances = {}
 
     def get_pre_create_attr_defs(self):
 
@@ -551,6 +538,10 @@ OTIO file.
         }
 
         instances = []
+        all_shot_instances = {}
+        vertical_clip_match = {}
+        vertical_clip_used = {}
+
         for idx, track_item in enumerate(sorted_selected_track_items):
             _instance_data = copy.deepcopy(instance_data)
             _instance_data["clip_index"] = track_item.guid()
@@ -558,6 +549,8 @@ OTIO file.
             # convert track item to timeline media pool item
             publish_clip = plugin.PublishClip(
                 track_item,
+                vertical_clip_match,
+                vertical_clip_used,
                 pre_create_data=pre_create_data,
                 rename_index=idx,
                 data=_instance_data,
@@ -590,7 +583,7 @@ OTIO file.
 
             # Create new product(s) instances.
             shot_folder_path = _instance_data["folderPath"]
-            shot_instances = self.shot_instances.setdefault(
+            shot_instances = all_shot_instances.setdefault(
                 shot_folder_path, {})
 
             # desable shot creator if heroTrack is not enabled
@@ -703,10 +696,6 @@ OTIO file.
                 }
             )
             instances.append(instance)
-
-        # restore all caches
-        plugin.PublishClip.restore_all_caches()
-        self.shot_instances = {}
 
         return instances
 

--- a/client/ayon_hiero/plugins/publish/collect_audio.py
+++ b/client/ayon_hiero/plugins/publish/collect_audio.py
@@ -19,8 +19,18 @@ class CollectAudio(pyblish.api.InstancePlugin):
         """
         # Retrieve instance data from parent instance shot instance.
         parent_instance_id = instance.data["parent_instance_id"]
-        edit_shared_data = instance.context.data["editorialSharedData"]
-        shot_instance_data = edit_shared_data[parent_instance_id]
+
+        try:
+            edit_shared_data = instance.context.data["editorialSharedData"]
+            shot_instance_data = edit_shared_data[parent_instance_id]
+
+        # Ensure shot instance related to the audio instance exists.
+        except KeyError:
+            raise PublishError(
+                f'Could not find shot instance for {instance.data["label"]}.'
+                " Please ensure it is set and enabled."
+            )
+
         instance.data.update(shot_instance_data)
 
         # Adjust instance data from parent otio timeline.

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -49,11 +49,19 @@ class CollectPlate(pyblish.api.InstancePlugin):
 
         # Retrieve instance data from parent instance shot instance.
         parent_instance_id = instance.data["parent_instance_id"]
-        edit_shared_data = instance.context.data["editorialSharedData"]
 
-        instance.data.update(
-            edit_shared_data[parent_instance_id]
-        )
+        try:
+            edit_shared_data = instance.context.data["editorialSharedData"]
+            instance.data.update(
+                edit_shared_data[parent_instance_id]
+            )
+
+        # Ensure shot instance related to the audio instance exists.
+        except KeyError:
+            raise PublishError(
+                f'Could not find shot instance for {instance.data["label"]}.'
+                " Please ensure it is set and enabled."
+            )
 
         track_item = instance.data["item"]
         clip_colorspace = track_item.sourceMediaColourTransform()


### PR DESCRIPTION
## Changelog Description

Changes:
* Properly detect missing `shot` instances from `audio` and `plate` products.
* Handle track name with spaces properly
* Code readability changes

## Additional review information
- report some of the changes from Resolve from https://github.com/ynput/ayon-resolve/pull/50

## Testing notes:
1. Should work exactly as before.
