### PR TITLE
Fix 'file' knob export for OCIOFileTransform.

### DIFF
--- a/client/ayon_hiero/plugins/publish/collect_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/collect_clip_effects.py
@@ -232,8 +232,15 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
             if knob in _ignoring_keys:
                 continue
 
+            # Hiero 15.1v3
+            # This seems to be a bug. The "file" knob
+            # is always returned as animated by the API.
+            # (even tho it's not even possible
+            # to set this knob as animated from the UI).
+            is_file_knob = knob == "file"
+
             # get animation if node is animated
-            if node[knob].isAnimated():
+            if not is_file_knob and node[knob].isAnimated():
                 # grab animation including handles
                 knob_anim = [node[knob].getValueAt(i)
                              for i in range(


### PR DESCRIPTION
## Changelog Description
I found this bug while working on https://github.com/ynput/ayon-traypublisher/issues/64

For weird reasons in Hiero 15.1v3 the `file` knob is always flagged as animated (even if this is technically not possible to animate such knobs from the UI). This confuses our effect exporter code.


## Additional review information
I haven't been able to check if this is a regression from Hiero, maybe it used to work properly with previous version.
Hopefully this fix should work with all Hiero versions.

## Testing notes:

Publish
1. Create a timeline with a clip in Hiero
2. Add a `OCIOFileTransform` effect onto the clip
3. Set the effect with a random LUT file path
4. Export the clip through the `create_shot_clip` creator (ensure `effects` are enabled)

Loader:
1. In Nuke gather the published `effect` as nodes
2. Ensure the effect is properly reconstructed, pointing to the LUT file resource
