### PR TITLE
AY-7529 Fix track_item gathering for vertical align plate instances.

### DIFF
--- a/client/ayon_hiero/plugins/publish/collect_audio.py
+++ b/client/ayon_hiero/plugins/publish/collect_audio.py
@@ -61,7 +61,7 @@ class CollectAudio(pyblish.api.InstancePlugin):
                 f'clip guid: {instance.data["clip_index"]}'
             )
 
-        instance.data["item"] = track_item
+        instance.data["trackItem"] = track_item
 
         # solve reviewable options
         review_switch = instance.data["creator_attributes"].get("review")

--- a/client/ayon_hiero/plugins/publish/collect_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/collect_clip_effects.py
@@ -19,7 +19,7 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
         effects = {}
         review = instance.data.get("review")
         review_track_index = instance.context.data.get("reviewTrackIndex")
-        item = instance.data["item"]
+        track_item = instance.data["trackItem"]
         product_name = instance.data.get("productName")
 
         if not instance.data["creator_attributes"]["publish_effects"]:
@@ -35,12 +35,11 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
         # frame range
         self.handle_start = instance.data["handleStart"]
         self.handle_end = instance.data["handleEnd"]
-        self.clip_in = int(item.timelineIn())
-        self.clip_out = int(item.timelineOut())
+        self.clip_in = int(track_item.timelineIn())
+        self.clip_out = int(track_item.timelineOut())
         self.clip_in_h = self.clip_in - self.handle_start
         self.clip_out_h = self.clip_out + self.handle_end
 
-        track_item = instance.data["item"]
         track = track_item.parent()
         track_index = track.trackIndex()
         tracks_effect_items = instance.context.data.get("tracksEffectItems")

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -45,7 +45,7 @@ class CollectPlate(pyblish.api.InstancePlugin):
                 f'clip guid: {instance.data["clip_index"]}'
             )
 
-        instance.data["item"] = track_item
+        instance.data["trackItem"] = track_item
 
         # solve reviewable options
         review_switch = instance.data["creator_attributes"].get(
@@ -80,7 +80,6 @@ class CollectPlate(pyblish.api.InstancePlugin):
                 " Please ensure it is set and enabled."
             )
 
-        track_item = instance.data["item"]
         clip_colorspace = track_item.sourceMediaColourTransform()
 
         # add colorspace data to versionData

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -45,7 +45,7 @@ class CollectShot(pyblish.api.InstancePlugin):
 
         # Adjust handles:
         # Explain
-        track_item = instance.data["item"]
+        track_item = instance.data["trackItem"]
         instance.data.update({
             "handleStart": min(
                 instance.data["handleStart"], int(track_item.handleInLength())),
@@ -116,7 +116,7 @@ class CollectShot(pyblish.api.InstancePlugin):
 
         instance.data.update({
             "annotations": self.clip_annotations(track_item.source()),
-            "item": track_item,
+            "trackItem": track_item,
             "subtracks": self.clip_subtrack(track_item),
             "tags": lib.get_track_item_tags(track_item),
         })

--- a/client/ayon_hiero/plugins/publish/extract_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/extract_clip_effects.py
@@ -13,7 +13,7 @@ class ExtractClipEffects(publish.Extractor):
     families = ["effect"]
 
     def process(self, instance):
-        item = instance.data["item"]
+        item = instance.data["trackItem"]
         effects = instance.data.get("effects")
 
         # skip any without effects

--- a/client/ayon_hiero/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_hiero/plugins/publish/extract_thumbnail.py
@@ -24,7 +24,7 @@ class ExtractThumbnail(publish.Extractor):
         self.create_thumbnail(staging_dir, instance)
 
     def create_thumbnail(self, staging_dir, instance):
-        track_item = instance.data["item"]
+        track_item = instance.data["trackItem"]
         track_item_name = track_item.name()
 
         # frames


### PR DESCRIPTION
## Changelog Description

Fix bug when vertically align plates, the item gathering was linking everything to the main plate instead of the the clip's item.
This messes up the effect detection process.

## Additional review information
Detailed information of the changes made to the product or service, providing an in-depth description of the updates and enhancements. This can include technical information, code examples and anything else needed for the review of the PR.

## Testing notes:
1. Create a timeline for `vertical align` feature with one "main" clip and a "sub" one.
2. Create and associate an effect to the main clip (e.g. `Transform`)
3. Publish and ensure that the effect is added for the main plate but no effect is detected for the sub-plate
