### PR TITLE
Renames plugin for clarity

### DIFF
--- a/client/ayon_hiero/plugins/publish/collect_audio.py
+++ b/client/ayon_hiero/plugins/publish/collect_audio.py
@@ -4,7 +4,7 @@ from ayon_core.pipeline import PublishError
 from ayon_hiero.api.otio import utils
 
 
-class CollectAudio(pyblish.api.InstancePlugin):
+class CollectEditorialAudio(pyblish.api.InstancePlugin):
     """Collect new audio."""
 
     order = pyblish.api.CollectorOrder - 0.48


### PR DESCRIPTION
## Changelog description

Renames `CollectAudio` to `CollectEditorialAudio` to better
reflect its purpose of collecting audio from editorial sources.

## Testing notes
1. open your testing timeline with audio clips
2. publish audio products
3. nothing should have been stopping you 

resolves https://github.com/ynput/ayon-hiero/issues/57