### PR TITLE
Chore: Use 'qtpy' for PySide imports

### DIFF
--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -15,10 +15,7 @@ import hiero
 
 from qtpy import QtWidgets, QtCore
 import ayon_api
-try:
-    from PySide import QtXml
-except ImportError:
-    from PySide2 import QtXml
+from qtpy import QtXml
 
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import (

--- a/client/ayon_hiero/api/otio/hiero_import.py
+++ b/client/ayon_hiero/api/otio/hiero_import.py
@@ -9,7 +9,7 @@ import os
 import hiero.core
 import hiero.ui
 
-import PySide2.QtWidgets as qw
+from qtpy import QtWidgets as qw
 
 try:
     from urllib import unquote

--- a/client/ayon_hiero/api/startup/Python/Startup/SpreadsheetExport.py
+++ b/client/ayon_hiero/api/startup/Python/Startup/SpreadsheetExport.py
@@ -8,13 +8,10 @@ import csv
 
 import hiero.core.events
 import hiero.ui
-try:
-    from PySide.QtGui import *
-    from PySide.QtCore import *
-except:
-    from PySide2.QtGui import *
-    from PySide2.QtWidgets import *
-    from PySide2.QtCore import *
+
+from qtpy.QtWidgets import QApplication, QAction, QFileDialog
+from qtpy.QtGui import QIcon, QDesktopServices
+from qtpy.QtCore import Qt, QModelIndex, QDir, QUrl
 
 
 ### Magic Widget Finding Methods - This stuff crawls all the PySide widgets, looking for an answer

--- a/client/ayon_hiero/api/startup/Python/Startup/otioexporter/OTIOExportUI.py
+++ b/client/ayon_hiero/api/startup/Python/Startup/otioexporter/OTIOExportUI.py
@@ -9,20 +9,18 @@ from .OTIOExportTask import (
     OTIOExportPreset
 )
 
+from qtpy import QtCore
+from qtpy.QtWidgets import QCheckBox
 try:
     # Hiero >= 11.x
-    from PySide2 import QtCore
-    from PySide2.QtWidgets import QCheckBox
     from hiero.ui.FnTaskUIFormLayout import TaskUIFormLayout as FormLayout
 
 except ImportError:
     # Hiero <= 10.x
-    from PySide import QtCore  # lint:ok
-    from PySide.QtGui import QCheckBox, QFormLayout  # lint:ok
-
-    FormLayout = QFormLayout  # lint:ok
+    from qtpy.QtWidgets import QFormLayout as FormLayout
 
 from ayon_hiero.api.otio import hiero_export
+
 
 class OTIOExportUI(hiero.ui.TaskUIBase):
     def __init__(self, preset):

--- a/client/ayon_hiero/api/startup/Python/Startup/project_helpers.py
+++ b/client/ayon_hiero/api/startup/Python/Startup/project_helpers.py
@@ -1,15 +1,9 @@
-try:
-    from PySide.QtGui import *
-    from PySide.QtCore import *
-except:
-    from PySide2.QtGui import *
-    from PySide2.QtWidgets import *
-    from PySide2.QtCore import *
-
 from hiero.core.util import uniquify, version_get, version_set
 import hiero.core
 import hiero.ui
 import nuke
+
+from qtpy.QtWidgets import QAction
 
 # A globally variable for storing the current Project
 gTrackedActiveProject = None

--- a/client/ayon_hiero/api/startup/Python/Startup/setFrameRate.py
+++ b/client/ayon_hiero/api/startup/Python/Startup/setFrameRate.py
@@ -4,13 +4,17 @@
 
 import hiero.core
 import hiero.ui
-try:
-  from PySide.QtGui import *
-  from PySide.QtCore import *
-except:
-  from PySide2.QtGui import *
-  from PySide2.QtCore import *
-  from PySide2.QtWidgets import *
+
+from qtpy.QtWidgets import (
+    QDialog,
+    QSizePolicy,
+    QFormLayout,
+    QLineEdit,
+    QDialogButtonBox,
+    QAction,
+    QMenu,
+)
+from qtpy.QtGui import QDoubleValidator, QIcon
 
 # Dialog for setting a Custom frame rate.
 class SetFrameRateDialog(QDialog):

--- a/client/ayon_hiero/api/startup/Python/StartupUI/PimpMySpreadsheet.py
+++ b/client/ayon_hiero/api/startup/Python/StartupUI/PimpMySpreadsheet.py
@@ -7,13 +7,9 @@
 import hiero.core
 import hiero.ui
 
-try:
-    from PySide.QtGui import *
-    from PySide.QtCore import *
-except:
-    from PySide2.QtGui import *
-    from PySide2.QtWidgets import *
-    from PySide2.QtCore import *
+from qtpy.QtCore import QObject, QSize, Qt, QRect
+from qtpy.QtGui import QIcon, QColor, QImage, QPixmap, QPen
+from qtpy.QtWidgets import QStyle, QLabel, QComboBox, QAction, QMenu
 
 # Set to True, if you wat "Set Status" right-click menu, False if not
 kAddStatusMenu = True

--- a/client/ayon_hiero/api/startup/Python/StartupUI/Purge.py
+++ b/client/ayon_hiero/api/startup/Python/StartupUI/Purge.py
@@ -8,13 +8,9 @@
 
 import hiero
 import hiero.core.find_items
-try:
-    from PySide.QtGui import *
-    from PySide.QtCore import *
-except:
-    from PySide2.QtGui import *
-    from PySide2.QtWidgets import *
-    from PySide2.QtCore import *
+
+from qtpy.QtWidgets import QAction, QMessageBox
+from qtpy.QtGui import QIcon
 
 
 class PurgeUnusedAction(QAction):

--- a/client/ayon_hiero/api/startup/Python/StartupUI/nukeStyleKeyboardShortcuts.py
+++ b/client/ayon_hiero/api/startup/Python/StartupUI/nukeStyleKeyboardShortcuts.py
@@ -3,13 +3,7 @@
 # Usage: Copy this file to ~/.hiero/Python/StartupUI/
 
 import hiero.ui
-try:
-    from PySide.QtGui import *
-    from PySide.QtCore import *
-except:
-    from PySide2.QtGui import *
-    from PySide2.QtWidgets import *
-    from PySide2.QtCore import *
+from qtpy.QtGui import QKeySequence
 
 #----------------------------------------------
 a = hiero.ui.findMenuAction('Import File(s)...')

--- a/client/ayon_hiero/api/startup/Python/StartupUI/otioimporter/__init__.py
+++ b/client/ayon_hiero/api/startup/Python/StartupUI/otioimporter/__init__.py
@@ -7,7 +7,7 @@ __credits__ = ["Jakub Jezek", "Daniel Flehner Heen"]
 import hiero.ui
 import hiero.core
 
-import PySide2.QtWidgets as qw
+from qtpy import QtWidgets as qw
 
 from ayon_hiero.api.otio.hiero_import import load_otio
 

--- a/client/ayon_hiero/api/startup/Python/StartupUI/setPosterFrame.py
+++ b/client/ayon_hiero/api/startup/Python/StartupUI/setPosterFrame.py
@@ -1,12 +1,7 @@
 import hiero.core
 import hiero.ui
-try:
-    from PySide.QtGui import *
-    from PySide.QtCore import *
-except:
-    from PySide2.QtGui import *
-    from PySide2.QtWidgets import *
-    from PySide2.QtCore import *
+
+from qtpy.QtWidgets import QAction
 
 
 def setPosterFrame(posterFrame=.5):


### PR DESCRIPTION
## Changelog Description
Use `qtpy` to import `Qt` modules.

## Additional review information
Newer versions of Nuke are using `PySide6` instead of `PySide2` and older version, which were using `PySide`, are not supported anymore.

## Testing notes:
1. Newest version of nuke integration works.
