### PR TITLE
Chore: Quickfix to use correct variable

### DIFF
--- a/client/ayon_hiero/api/startup/Python/Startup/project_helpers.py
+++ b/client/ayon_hiero/api/startup/Python/Startup/project_helpers.py
@@ -69,7 +69,7 @@ def activeProject():
                 # It's possible that there is no selection in a Timeline/Spreadsheet, but these views have "sequence" method, so try that...
                 if isinstance(hiero.ui.activeView(), (hiero.ui.TimelineEditor, hiero.ui.SpreadsheetView)):
                     activeSequence = activeView.sequence()
-                    if hasattr(currentItem, "project"):
+                    if hasattr(activeSequence, "project"):
                         activeProject = activeSequence.project()
 
             # The active view has a selection... assume that the first item in the selection has the active Project


### PR DESCRIPTION
## Changelog Description
Use correct variable to get active project.

## Additional review information
Found out this bug during modifications of https://github.com/ynput/ayon-hiero/pull/60.

## Testing notes:
No idea how to test it.
