### PR TITLE
Adds support for JSON tag metadata

### DIFF
--- a/client/ayon_hiero/plugins/publish/collect_tag_tasks.py
+++ b/client/ayon_hiero/plugins/publish/collect_tag_tasks.py
@@ -1,4 +1,5 @@
 from pyblish import api
+import json
 
 
 class CollectClipTagTasks(api.InstancePlugin):
@@ -15,16 +16,26 @@ class CollectClipTagTasks(api.InstancePlugin):
 
         tasks = {}
         for tag in tags:
-            t_metadata = dict(tag.metadata())
-            t_product_type = t_metadata.get("tag.productType")
-            if t_product_type is None:
-                t_product_type = t_metadata.get("tag.family", "")
 
-            # gets only task product type tags and collect labels
-            if "task" in t_product_type:
-                t_task_name = t_metadata.get("tag.label", "")
-                t_task_type = t_metadata.get("tag.type", "")
-                tasks[t_task_name] = {"type": t_task_type}
+            t_metadata = dict(tag.metadata())
+            if t_metadata.get("tag.json_metadata"):
+                metadata = json.loads(t_metadata["tag.json_metadata"])
+                product_type = metadata.get("productType")
+                if product_type == "task":
+                    task_type = metadata.get("type")
+                    task_name = t_metadata.get("tag.label", "")
+                    tasks[task_name] = {"type": task_type}
+            else:
+                # backward compatiblity for older tags
+                t_product_type = t_metadata.get("tag.productType")
+                if t_product_type is None:
+                    t_product_type = t_metadata.get("tag.family", "")
+
+                # gets only task product type tags and collect labels
+                if "task" in t_product_type:
+                    t_task_name = t_metadata.get("tag.label", "")
+                    t_task_type = t_metadata.get("tag.type", "")
+                    tasks[t_task_name] = {"type": t_task_type}
 
         instance.data["tasks"] = tasks
 


### PR DESCRIPTION
## Changelog description

Adds the ability to use JSON metadata within tags.

This change allows for more complex and structured data to be stored within tags, offering a more flexible approach compared to the previous key-value system. It maintains backward compatibility with older tags that use the legacy metadata format.


## Additional information
This had been broken by implementation of new publisher workflow. We are also supporting older tags just in case.

## Testing steps
1. open any of your testing Hiero project
2. have some clips with created plate products
3. go to your Tags library and remove all workfile related tags
4. Go to AYON menu and use `Create Default Tags`
5. Drag and drop task related tag to any of your clip and select it
6. Open publisher and hit Validate
7. To to Details and search for Collect Task Tags. Look into logs and see if there is some discovered task related tag. If it is then mission accomplished. 