### PR TITLE
Enhancement/ay 7197 expose source resolution

### DIFF
--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -167,6 +167,14 @@ class HieroShotInstanceCreator(_HieroInstanceCreator):
 
     def get_instance_attr_defs(self):
         instance_attributes = CLIP_ATTR_DEFS
+        instance_attributes.append(
+            BoolDef(
+                "sourceResolution",
+                label="Set shot resolution from plate",
+                tooltip="Is resolution taken from timeline or source?",
+                default=False,
+            )
+        )
         return instance_attributes
 
 
@@ -636,6 +644,7 @@ OTIO file.
                             "clipDuration": track_item_duration,
                             "sourceIn": track_item.sourceIn(),
                             "sourceOut": track_item.sourceOut(),
+                            "sourceResolution": sub_instance_data["sourceResolution"],
                         }
                     )
 
@@ -825,6 +834,7 @@ OTIO file.
                 "clipDuration": track_item_duration,
                 "sourceIn": track_item.sourceIn(),
                 "sourceOut": track_item.sourceOut(),
+                "sourceResolution": sub_instance_data.get("sourceResolution", False),
             }
         })
 

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -97,7 +97,8 @@ class CollectShot(pyblish.api.InstancePlugin):
         inst_data = marker_metadata["hiero_sub_products"].get(creator_id, {})
 
         # Overwrite settings with clip metadata is "sourceResolution"
-        overwrite_clip_metadata = inst_data.get("sourceResolution", False)
+        overwrite_clip_metadata = instance.data['creator_attributes'].get(
+            "sourceResolution", False)
         active_timeline = instance.context.data["activeTimeline"]
 
         # Adjust info from track_item on timeline

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -85,15 +85,11 @@ class CollectShot(pyblish.api.InstancePlugin):
             raise PublishError(
                 f"Could not retrieve otioClip for shot {instance}")
 
+        instance.data["otioClip"] = otio_clip
+
         # Compute fps from creator attribute.
         if instance.data['creator_attributes']["fps"] == "from_selection":
             instance.data['creator_attributes']["fps"] = instance.context.data["fps"]
-
-        # Retrieve AyonData marker for associated clip.
-        instance.data["otioClip"] = otio_clip
-        creator_id = instance.data["creator_identifier"]
-
-        marker_metadata = json.loads(marker.metadata["json_metadata"])
 
         # Overwrite settings with clip metadata is "sourceResolution"
         overwrite_clip_metadata = instance.data['creator_attributes'].get(

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -1,4 +1,3 @@
-import json
 import pyblish
 
 from ayon_core.pipeline import PublishError

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -94,7 +94,6 @@ class CollectShot(pyblish.api.InstancePlugin):
         creator_id = instance.data["creator_identifier"]
 
         marker_metadata = json.loads(marker.metadata["json_metadata"])
-        inst_data = marker_metadata["hiero_sub_products"].get(creator_id, {})
 
         # Overwrite settings with clip metadata is "sourceResolution"
         overwrite_clip_metadata = instance.data['creator_attributes'].get(


### PR DESCRIPTION
## Changelog Description

helps resolve https://github.com/ynput/ayon-core/issues/1289

Hiero `Create Publishable Clip` creator supports a `sourceResolution` attribute, that allow the new shot to be created to pick-up its resolution from the hero plate instead of the timeline.
This attribute was only exposed as creator level and not anymore, this PR brings it as `creator_attributes` for shot instance(s).
![image](https://github.com/user-attachments/assets/7fc324c3-6e87-4509-aec7-afbf0819f881)

## Additional info

This will need to be reported in Flame and Resolve.

## Testing notes:
1. Ensure this attribute is properly exposed for shots, for existing and new created instances.