### PR TITLE
Fix obsolete QPixmap.grabWidget method.

### DIFF
--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -148,7 +148,8 @@ def get_current_sequence(name=None, new=False):
 
 def get_timeline_selection():
     active_sequence = hiero.ui.activeSequence()
-    if active_sequence is None:  # no active timeline
+    # There is no active timeline
+    if active_sequence is None:
         return []
 
     timeline_editor = hiero.ui.getTimelineEditor(active_sequence)

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -148,6 +148,9 @@ def get_current_sequence(name=None, new=False):
 
 def get_timeline_selection():
     active_sequence = hiero.ui.activeSequence()
+    if active_sequence is None:  # no active timeline
+        return []
+
     timeline_editor = hiero.ui.getTimelineEditor(active_sequence)
     return list(timeline_editor.selection())
 

--- a/client/ayon_hiero/plugins/publish/extract_workfile.py
+++ b/client/ayon_hiero/plugins/publish/extract_workfile.py
@@ -44,11 +44,7 @@ class ExtractWorkfile(publish.Extractor):
                     if active_timeline.name() in w.windowTitle()]
 
         # export window to thumb path
-        try:
-            pixmap = QPixmap.grabWidget(_windows[-1])
-        # https://doc.qt.io/archives/qt-5.15/qpixmap-obsolete.html#grabWidget
-        except AttributeError:
-            pixmap = _windows[-1].grab()
+        pixmap = _windows[-1].grab()
 
         pixmap.save(thumbnail_path, 'png')
 

--- a/client/ayon_hiero/plugins/publish/extract_workfile.py
+++ b/client/ayon_hiero/plugins/publish/extract_workfile.py
@@ -6,8 +6,6 @@ from ayon_core.pipeline import publish
 import hiero
 import tempfile
 
-from qtpy.QtGui import QPixmap
-
 
 class ExtractWorkfile(publish.Extractor):
     """
@@ -45,7 +43,6 @@ class ExtractWorkfile(publish.Extractor):
 
         # export window to thumb path
         pixmap = _windows[-1].grab()
-
         pixmap.save(thumbnail_path, 'png')
 
         # thumbnail

--- a/client/ayon_hiero/plugins/publish/extract_workfile.py
+++ b/client/ayon_hiero/plugins/publish/extract_workfile.py
@@ -44,7 +44,13 @@ class ExtractWorkfile(publish.Extractor):
                     if active_timeline.name() in w.windowTitle()]
 
         # export window to thumb path
-        QPixmap.grabWidget(_windows[-1]).save(thumbnail_path, 'png')
+        try:
+            pixmap = QPixmap.grabWidget(_windows[-1])
+        # https://doc.qt.io/archives/qt-5.15/qpixmap-obsolete.html#grabWidget
+        except AttributeError:
+            pixmap = _windows[-1].grab()
+
+        pixmap.save(thumbnail_path, 'png')
 
         # thumbnail
         thumb_representation = {


### PR DESCRIPTION
## Changelog Description

Changes:
* `QPixmap.grabWidget` is deprecated from `PySide6`. Prepare this change for the future.
* Handle no active sequence in Hiero for creators

## Testing notes:
1. Deploy Hiero with PySide6 (I used `Hiero 16.0v3`)
2. Ensure you can publish a `workfile`
