### PR TITLE
Extend lib module to allow tag creation within the AYON project bin.

### DIFF
--- a/client/ayon_hiero/api/tags.py
+++ b/client/ayon_hiero/api/tags.py
@@ -118,13 +118,14 @@ def get_tag_data(tag):
         return {}
 
 
-def get_or_create_workfile_tag(create=False):
+def get_or_create_workfile_tag(tag_name, create=False):
     """
     Args:
+        tag_name (str): The name of the tag to create.
         create (bool): Create the project tag if missing.
 
     Returns:
-        hiero.core.Tag: The workfile tag or None
+        hiero.core.Tag: The ayon tag or None
     """
     from .lib import get_current_project  # noqa prevent-circular-import
     current_project = get_current_project()
@@ -143,12 +144,34 @@ def get_or_create_workfile_tag(create=False):
     # retrieve tag
     for item in tag_bin.items():
         if (isinstance(item, hiero.core.Tag)
-            and item.name() == constants.AYON_WORKFILE_TAG_NAME):
+            and item.name() == tag_name):
             return item
 
-    workfile_tag = hiero.core.Tag(constants.AYON_WORKFILE_TAG_NAME)
+    workfile_tag = hiero.core.Tag(tag_name)
     tag_bin.addItem(workfile_tag)
     return workfile_tag
+
+
+def remove_workfile_tag(tag_name):
+    """
+    Args:
+        tag_name (str): The name of the tag to create.
+    """
+    from .lib import get_current_project  # noqa prevent-circular-import
+    current_project = get_current_project()
+
+    project_tag_bin = current_project.tagsBin()
+    for tag_bin in project_tag_bin.bins():
+        if tag_bin.name() != constants.AYON_WORKFILE_TAG_BIN:
+            continue
+
+        for item in tag_bin.items():
+            if (
+                isinstance(item, hiero.core.Tag)
+                and item.name() == tag_name
+            ):
+                tag_bin.removeItem(item)
+                return
 
 
 def add_tags_to_workfile():

--- a/client/ayon_hiero/plugins/create/create_workfile.py
+++ b/client/ayon_hiero/plugins/create/create_workfile.py
@@ -2,7 +2,7 @@
 """Creator plugin for creating workfiles."""
 from ayon_core.pipeline.create import CreatedInstance, AutoCreator
 
-from ayon_hiero.api import tags
+from ayon_hiero.api import tags, constants
 
 
 class CreateWorkfile(AutoCreator):
@@ -23,7 +23,10 @@ class CreateWorkfile(AutoCreator):
         Args:
             data (dict): The data to push to the project tag.
         """
-        project_tag = tags.get_or_create_workfile_tag(create=True)
+        project_tag = tags.get_or_create_workfile_tag(
+            constants.AYON_WORKFILE_TAG_NAME,
+            create=True
+        )
 
         tag_data = {
             "metadata": data,
@@ -37,7 +40,9 @@ class CreateWorkfile(AutoCreator):
         Returns:
             dict. The project data.
         """
-        project_tag = tags.get_or_create_workfile_tag()
+        project_tag = tags.get_or_create_workfile_tag(
+            constants.AYON_WORKFILE_TAG_NAME
+        )
         if project_tag is None:
             return {}
 


### PR DESCRIPTION
## Changelog Description
Changes:
* Extend existing `get_or_create_workfile_tag` function to create tags with custom names
* Add a function to remove Hiero tag from AYON project bin

## Additional notes
Those changes are required to ease the implementation of:
https://github.com/ynput/ayon-sn4/pull/15

## Testing notes:
1. Ensure `workfile` auto-creator from Hiero still works as before
