### PR TITLE
Report existing editorial_pkg product from Resolve in Hiero.

### DIFF
--- a/client/ayon_hiero/api/otio/hiero_export.py
+++ b/client/ayon_hiero/api/otio/hiero_export.py
@@ -1,6 +1,7 @@
 """ compatibility OpenTimelineIO 0.12.0 and newer
 """
 
+from typing import Optional
 import os
 import re
 import opentimelineio as otio
@@ -373,10 +374,12 @@ def add_otio_metadata(otio_item, media_source, **kwargs):
         otio_item.metadata.update({key: value})
 
 
-def create_otio_timeline():
+def create_otio_timeline(
+    sequence: Optional[hiero.core.Sequence] = None,
+) -> otio.schema.Timeline:
 
     # get current timeline
-    CTX.timeline = hiero.ui.activeSequence()
+    CTX.timeline = sequence or hiero.ui.activeSequence()
     CTX.project_fps = CTX.timeline.framerate().toFloat()
 
     # convert timeline to otio

--- a/client/ayon_hiero/api/pipeline.py
+++ b/client/ayon_hiero/api/pipeline.py
@@ -28,7 +28,7 @@ from ayon_core.tools.utils import host_tools
 
 from ayon_hiero import HIERO_ADDON_ROOT
 
-from . import lib, menu, events
+from . import lib, tags, menu, events
 from .workio import (
     open_file,
     save_file,
@@ -145,7 +145,7 @@ def containerise(track_item,
 def ls():
     """List available containers.
 
-    This function is used by the Container Manager in Nuke. You'll
+    This function is used by the Container Manager in Hiero. You'll
     need to implement a for-loop that then *yields* one Container at
     a time.
 
@@ -170,6 +170,16 @@ def ls():
                 yield _c
         elif container_data:
             yield container_data
+
+    # get container from tags
+    tag_bin = tags.get_workfile_bin()
+    if not tag_bin:
+        return
+
+    for tag_item in tag_bin.items():
+        tag_data = tags.get_tag_data(tag_item)
+        if tag_data.get("schema") == "ayon:container-3.0":
+            yield tag_data
 
 
 def parse_container(item, validate=True):

--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -323,7 +323,7 @@ class Spacer(QtWidgets.QWidget):
 
 
 class SequenceLoader(LoaderPlugin):
-    """A basic SequenceLoader for Resolve
+    """A basic SequenceLoader for Hiero
 
     This will implement the basic behavior for a loader to inherit from that
     will containerize the reference and will implement the `remove` and

--- a/client/ayon_hiero/api/rendering.py
+++ b/client/ayon_hiero/api/rendering.py
@@ -1,0 +1,62 @@
+from typing import Optional
+
+from ayon_hiero.api import lib
+
+import hiero.core
+import hiero.exporters
+
+from hiero.core import TimelineDirectExport
+
+
+def render_sequence_as_quicktime(
+        output_path: str,
+        sequence: Optional[hiero.core.Sequence] = None,
+        export_audio: Optional[bool] = True,
+    ):
+    project = lib.get_current_project()
+    if not sequence:
+        sequence = lib.get_current_sequence()
+    elif sequence not in project.sequences():
+        raise ValueError(f"Unknown sequence to render {sequence}.")
+
+    # https://learn.foundry.com/hiero/developers/latest/HieroPythonDevGuide/quick_export.html
+    h264_export = {
+      "Audio Codec" : "linear PCM (wav)",
+      "B Frames" : "0",
+      "Bit Depth" : "32 bit(float)",
+      "Bitrate" : "28000.0",
+      "Bitrate Tolerance" : "0",
+      "Codec" : "H.264",
+      "Codec Profile" : "High 4:2:0 8-bit",
+      "Data Range" : "Video Range",
+      "Fast Start" : "True",
+      "Format_height" : "720",
+      "Format_name" : "HD_720",
+      "Format_pixelAspect" : "1.0",
+      "Format_width" : "1280",
+      "GOP Size" : "12",
+      "Include Audio" : "True" if export_audio else "False",
+      "Include Annotations": "False",
+      "Output Channels" : "stereo",
+      "Quality" : "High",
+      "Quantizer Max" : "3",
+      "Quantizer Min" : "1",
+      "Reformat" : "Custom",
+      "Sample Rate" : "48000 Hz",
+      "Views" : "main",
+      "Write Timecode" : "True",
+      "YCbCr Matrix" : "Auto",
+      "center" : "True",
+      "colorspace" : "default",
+      "ocioDisplay" : "default",
+      "ocioView" : "sRGB",
+      "resize" : "width",
+      "transformType" : "colorspace"
+    }
+
+    exportObj = TimelineDirectExport()
+    exportObj.exportSequence(
+        sequence,
+        output_path,
+        h264_export
+    )

--- a/client/ayon_hiero/api/tags.py
+++ b/client/ayon_hiero/api/tags.py
@@ -120,18 +120,9 @@ def get_tag_data(tag):
         return {}
 
 
-def get_or_create_workfile_tag(
-    tag_name: str, create: bool = False
-) -> Optional[hiero.core.Tag]:
-    """
-    Args:
-        tag_name (str): The name of the tag to create.
-        create (bool): Create the project tag if missing.
-
-    Returns:
-        hiero.core.Tag: The AYON tag or None
-
-    """
+def get_workfile_bin(
+        create: bool = False,
+    ) -> Optional[hiero.core.Tag]:
     from .lib import get_current_project  # noqa prevent-circular-import
     current_project = get_current_project()
 
@@ -147,6 +138,25 @@ def get_or_create_workfile_tag(
             return None
 
     # retrieve tag
+    return tag_bin
+
+
+def get_or_create_workfile_tag(
+    tag_name: str, create: bool = False
+) -> Optional[hiero.core.Tag]:
+    """
+    Args:
+        tag_name (str): The name of the tag to create.
+        create (bool): Create the project tag if missing.
+
+    Returns:
+        hiero.core.Tag: The AYON tag or None
+
+    """
+    tag_bin = get_workfile_bin(create=create)
+    if not tag_bin:
+        return None
+
     for item in tag_bin.items():
         if (isinstance(item, hiero.core.Tag)
             and item.name() == tag_name):

--- a/client/ayon_hiero/plugins/create/create_editorial_pkg.py
+++ b/client/ayon_hiero/plugins/create/create_editorial_pkg.py
@@ -1,0 +1,122 @@
+from typing import Dict, List, Any
+
+from ayon_core.pipeline.create import CreatedInstance, CreatorError
+from ayon_core.lib import BoolDef, AbstractAttrDef
+
+from ayon_hiero.api import plugin, tags, lib, constants
+
+import hiero
+
+
+_CREATE_ATTR_DEFS = [
+    BoolDef(
+        "review",
+        label="Make intermediate media reviewable",
+        tooltip="Make editorial package intermediate media reviewable.",
+        default=False,
+    )
+]
+
+
+class CreateEditorialPackage(plugin.HieroCreator):
+    """Create Editorial Package."""
+
+    identifier = "io.ayon.creators.hiero.editorial_pkg"
+    label = "Editorial Package"
+    product_type = "editorial_pkg"
+    icon = "camera"
+    defaults = ["Main"]
+
+    def get_pre_create_attr_defs(self) -> List[AbstractAttrDef]:
+        return _CREATE_ATTR_DEFS
+
+    def get_attr_defs_for_instance(
+            self,
+            instance: CreatedInstance
+        ) -> List[AbstractAttrDef]:
+        return _CREATE_ATTR_DEFS
+
+    @classmethod
+    def _get_edl_tag_name(cls, guid: str) -> str:
+        return f"{guid}_{cls.product_type}"
+
+    @classmethod
+    def dump_instance_data(
+            cls,
+            guid: str,
+            data: Dict,
+        ):
+        edpkg_tag = tags.get_or_create_workfile_tag(
+            cls._get_edl_tag_name(guid),
+            create=True
+        )
+        tag_data = {
+            "metadata": data,
+            "note": "AYON editorial pkg data",
+        }
+        tags.update_tag(edpkg_tag, tag_data)
+
+    def create(
+            self,
+            product_name: str,
+            instance_data: Dict[str, Any],
+            pre_create_data: Dict[str, Any]
+        ):
+        super().create(
+            product_name,
+            instance_data,
+            pre_create_data
+        )
+
+        current_sequence = lib.get_current_sequence()
+        if current_sequence is None:
+            raise CreatorError("No active sequence.")
+
+        instance_data["guid"] = current_sequence.guid()
+        instance_data["creator_attributes"] = {
+            "review": pre_create_data["review"]
+        }
+
+        new_instance = CreatedInstance(
+            self.product_type,
+            product_name,
+            instance_data,
+            self
+        )
+        self._add_instance_to_context(new_instance)
+
+    def collect_instances(self):
+        current_project = lib.get_current_project()
+        project_tag_bin = current_project.tagsBin()
+        for tag_bin in project_tag_bin.bins():
+            if tag_bin.name() != constants.AYON_WORKFILE_TAG_BIN:
+                continue
+
+            for item in tag_bin.items():
+                if (
+                    not isinstance(item, hiero.core.Tag)
+                    or not item.name().endswith(self.product_type)
+                ):
+                    continue
+
+                instance_data = tags.get_tag_data(item)
+                instance = CreatedInstance(
+                    self.product_type,
+                    instance_data["productName"],
+                    instance_data,
+                    self
+                )
+                self._add_instance_to_context(instance)
+
+    def update_instances(self, update_list: List[CreatedInstance]):
+        for created_inst, _ in update_list:
+            data = created_inst.data_to_store()
+            guid = created_inst.data["guid"]
+            self.dump_instance_data(guid, data)
+
+    def remove_instances(self, instances: List[CreatedInstance]):
+        for inst in instances:
+            guid = inst.data["guid"]
+            tag_name = self._get_edl_tag_name(guid)
+            tags.remove_workfile_tag(tag_name)
+            self._remove_instance_from_context(inst)

--- a/client/ayon_hiero/plugins/load/load_editorial_package.py
+++ b/client/ayon_hiero/plugins/load/load_editorial_package.py
@@ -1,0 +1,91 @@
+from typing import Dict, Any
+from pathlib import Path
+import os
+import glob
+
+
+from ayon_core.pipeline import (
+    AVALON_CONTAINER_ID,
+    load,
+    get_representation_path,
+)
+
+from ayon_hiero.api import lib, tags
+
+import hiero.core
+
+
+class LoadEditorialPackage(load.LoaderPlugin):
+    """Load editorial package to timeline.
+    """
+    product_types = {"editorial_pkg"}
+
+    representations = {"*"}
+    extensions = {"otio"}
+
+    label = "Load as Timeline"
+    order = -10
+    icon = "ei.align-left"
+    color = "orange"
+
+    @classmethod
+    def _get_container_data(
+            cls,
+            context: Dict[str, Any],
+            seq: hiero.core.Sequence
+        ) -> Dict[str, str]:
+        version_entity = context["version"]
+        return {
+            "schema": "ayon:container-3.0",
+            "id": AVALON_CONTAINER_ID,
+            "loader": str(cls.__name__),
+            "author": version_entity["data"]["author"],
+            "representation": context["representation"]["id"],
+            "version": version_entity["version"],
+            "name": seq.guid(),
+            "namespace": seq.name(),
+            "objectName": seq.name(),
+        }
+
+    def load(self, context, name, namespace, data):
+        files = get_representation_path(context["representation"])
+        seq_bin = lib.create_bin(f"/{name}")
+
+        # Load clip
+        dirname = os.path.dirname(files)
+        media_paths = glob.glob(Path(dirname,"*.mov").as_posix())
+        conf_media_path = Path(media_paths[0]).as_posix()
+        seq_bin.createClip(conf_media_path)
+
+        # Load sequence from otio
+        seq = seq_bin.importSequence(files)
+
+        # Remap all clip to loaded clip
+        # (for some reasons, Hiero does not link the media properly)
+        for track in seq.items():
+            for track_item in track.items():
+                track_item.replaceClips(conf_media_path)
+
+        # Set Tag for loaded instance
+        edpkg_tag = tags.get_or_create_workfile_tag(
+            f"{seq.guid()}_{name}",
+            create=True
+        )
+        tag_data = {
+            "metadata": self._get_container_data(context, seq),
+            "note": "AYON editorial pkg data",
+        }
+        tags.update_tag(edpkg_tag, tag_data)
+
+    def update(self, container, context):
+        """Update the container with the latest version."""
+        product_name = context["product"]["name"]
+        seq_guid = container["name"]
+        tags.remove_workfile_tag(f"{seq_guid}_{product_name}",)
+
+        self.load(
+            context,
+            product_name,
+            container["namespace"],
+            container,
+        )

--- a/client/ayon_hiero/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_hiero/plugins/publish/collect_editorial_package.py
@@ -1,0 +1,31 @@
+import pyblish.api
+
+
+from ayon_core.pipeline import PublishError
+from ayon_hiero.api import lib
+
+
+
+class CollectEditorialPackages(pyblish.api.InstancePlugin):
+    """Collect all Editorial Packages."""
+
+    order = pyblish.api.CollectorOrder - 0.49
+    label = "Collect Editorial Package Instances"
+    families = ["editorial_pkg"]
+
+    def process(self, instance: pyblish.api.Instance):
+        current_project = lib.get_current_project()
+        all_sequences = current_project.sequences()
+        hiero_sequence_guid = instance.data["guid"]
+
+        hiero_sequence = None
+        for sequence in all_sequences:
+            if sequence.guid() == hiero_sequence_guid:
+                hiero_sequence = sequence
+                instance.data["hiero_sequence"] = sequence
+                break
+
+        if not hiero_sequence:
+            raise PublishError(f"Cannot retrieve sequence from {hiero_sequence}.")
+
+        self.log.debug(f"Editorial Package: {instance.data}")

--- a/client/ayon_hiero/plugins/publish/extract_editorial_package.py
+++ b/client/ayon_hiero/plugins/publish/extract_editorial_package.py
@@ -1,0 +1,145 @@
+from typing import Dict, Any
+import os
+from pathlib import Path
+
+import pyblish.api
+import opentimelineio as otio
+
+from ayon_core.pipeline import publish
+
+from ayon_hiero.api import rendering
+from ayon_hiero.api.otio import hiero_export
+
+
+class ExtractEditorialPackage(publish.Extractor):
+    """Extract and Render intermediate file for Editorial Package"""
+
+    label = "Extract Editorial Package"
+    order = pyblish.api.ExtractorOrder + 0.45
+    families = ["editorial_pkg"]
+
+    @staticmethod
+    def _get_anticipated_publish_path(
+            instance: pyblish.api.Instance,
+            repre_data: Dict[str, Any],
+        ) -> str:
+        anatomy = instance.context.data["anatomy"]
+        template_data = instance.data.get("anatomyData")
+        template_data["root"] = anatomy.roots
+        template_data["representation"] = repre_data["name"]
+        template_data["ext"] = repre_data["ext"]
+        template_data["comment"] = None
+
+        template = anatomy.get_template_item("publish", "default", "path")
+        template_filled = template.format_strict(template_data)
+        file_path = Path(template_filled)
+        return file_path.as_posix()
+
+    @staticmethod
+    def _remap_all_clips_to_media(
+            otio_timeline: otio.schema.Timeline,
+            media_path: str
+        ):
+
+        # Make new media reference to store in clips
+        timeline_fps = otio_timeline.duration().rate
+        timeline_duration = otio_timeline.duration().to_frames()
+        timeline_start_frame = otio_timeline.global_start_time.to_frames()
+        new_media_reference = otio.schema.ExternalReference(
+            target_url=media_path,
+            available_range=otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(
+                    value=timeline_start_frame,
+                    rate=timeline_fps,
+                ),
+                duration=otio.opentime.RationalTime(
+                    value=timeline_duration,
+                    rate=timeline_fps,
+                ),
+            ),
+        )
+
+        # Remap all media clips from the timeline
+        for track in otio_timeline.tracks:
+            for clip in track:
+                if (
+                    not hasattr(clip, "media_reference")
+                ):
+                    # Skip non-media related clips
+                    continue
+
+                clip.media_reference = new_media_reference
+                clip.source_range = otio.opentime.TimeRange(
+                    start_time=otio.opentime.RationalTime(
+                        value=(
+                            timeline_start_frame
+                            + clip.range_in_parent().start_time.value
+                        ),
+                        rate=timeline_fps,
+                    ),
+                    duration=clip.range_in_parent().duration,
+                )
+
+    def process(self, instance: pyblish.api.Instance):
+        if "representations" not in instance.data:
+            instance.data["representations"] = []
+
+        temp_dir = self.staging_dir(instance)
+        seq = instance.data["hiero_sequence"]
+
+        # Export timeline as consolidated media
+        output_video = os.path.join(
+            temp_dir,
+            f"{seq.guid()}_intermediate.mov"
+        )
+        rendering.render_sequence_as_quicktime(
+            output_video,
+            sequence=seq
+        )
+        intermediate_repre = {
+            "name": "intermediate",
+            "ext": "mov",
+            "files": os.path.basename(output_video),
+            "stagingDir": temp_dir,
+            "tags": ["review"]
+        }
+        instance.data["representations"].append(intermediate_repre)
+        published_path = self._get_anticipated_publish_path(
+            instance,
+            intermediate_repre
+        )
+        self.log.info(
+            "Added intermediate file representation: "
+            f"{intermediate_repre}"
+        )
+
+        # Export sequence as OTIO but remap to rendered consolidated media
+        otio_timeline = hiero_export.create_otio_timeline(
+            sequence=seq,
+        )
+        self._remap_all_clips_to_media(
+            otio_timeline,
+            published_path,
+        )
+
+        # Export resulting OTIO file and add as representation.
+        remap_otio_file = os.path.join(
+            temp_dir,
+            f"{seq.guid()}_remap.otio"
+        )
+        otio.adapters.write_to_file(
+            otio_timeline,
+            remap_otio_file
+        )
+        representation_otio = {
+            "name": "editorial_pkg",
+            "ext": "otio",
+            "files": os.path.basename(remap_otio_file),
+            "stagingDir": temp_dir,
+        }
+        instance.data["representations"].append(representation_otio)
+
+        self.log.info(
+            "Added OTIO file representation: "
+            f"{representation_otio}"
+        )


### PR DESCRIPTION
## Changelog Description
This PR adds the `editorial_pkg` feature as it already exists in `ayon_resolve`.
From a `hiero.core.Sequence`, the `editorial_pkg` publish a visual representation of the whole timeline as a consolidated video file, then it also export an OTIO edl representation of the sequence pointing to the consolidated media. 

Changes:
* Implemented creator for `editorial_pkg`
* Add `collect` and `extract` publish plugins for `editorial_pkg`
* Add loader for `editorial_pkg`

## Testing notes:
1. Create a timeline in Hiero with multiple tracks and multiple clips (no retime)
2. Ensure your timeline is current, then create a new editorial_pkg through the creator
3. Publish
4. Load the result through the loader menu
5. Ensure the visual of resulting loaded timeline matches the initial one visually but pointing to the intermediate review file
