### PR TITLE
Fix clip offset due to slate not being taken in to account

### DIFF
--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -554,8 +554,7 @@ class ClipLoader:
         log.debug("__ self.timeline_out: {}".format(self.timeline_out))
 
         # check if slate is included
-        slate_on = "slate" in self.context["version"]["data"].get(
-            "families", [])
+        slate_on = "slate" in version_attributes.get("families", [])
         log.debug("__ slate_on: {}".format(slate_on))
 
         # if slate is on then remove the slate frame from beginning


### PR DESCRIPTION
[Here](https://github.com/ynput/ayon-hiero/issues/35) the related issue. 

## Changelog Description

Issue comes from the following line:
```
-        slate_on = "slate" in self.context["version"]["data"].get(
-            "families", [])
```

This data is not stored anymore in `self.context["version"]["data"]` but in `self.context["version"]["attrib"]`. Therefore return value was always `[]`. Not entering in this if statement 
```
        # if slate is on then remove the slate frame from beginning
        if slate_on:
            self.media_duration -= 1
            self.handle_start += 1
 ```

 and causing handles to be `-8 +9` instead of `-9 +8` in the loaded clip if version had a slate frame (in our tests handles were set to 8 but this happens with any value).

## Testing notes:

- Launch Hiero.
- Load a render product that has a slate frame. 
-  Check  handles are correct . It should have a +1 in the start handle instead of at the end (so if handles are 8 start and 8 end, loaded clip should have 9 at the start and 8 at the end).  