### PR TITLE
Fixes clip loader track assignment

### DIFF
--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -384,6 +384,7 @@ class ClipLoader:
 
     active_bin = None
     data = dict()
+    active_track = None
 
     def __init__(self, cls, context, path, **options):
         """ Initialize object
@@ -433,9 +434,16 @@ class ClipLoader:
         else:
             self.active_sequence = lib.get_current_sequence()
 
-        if options.get("track"):
-            # if multiselection is set then use options track
-            self.active_track = options["track"]
+        # check if track already exists
+        matching_track = None
+        for _track in self.active_sequence.videoTracks():
+            if _track.name() == self.data["track_name"]:
+                matching_track = _track
+
+        # if multiselection is set then use options track
+        # in case it is existing track
+        if options.get("track") and matching_track:
+            self.active_track = matching_track
         else:
             self.active_track = lib.get_current_track(
                 self.active_sequence, self.data["track_name"])

--- a/client/ayon_hiero/plugins/load/load_effects.py
+++ b/client/ayon_hiero/plugins/load/load_effects.py
@@ -287,7 +287,7 @@ class LoadEffects(load.LoaderPlugin):
 
         data_imprint = {
             object_name: {
-                "schema": "ayon:container-2.0",
+                "schema": "ayon:container-3.0",
                 "id": AVALON_CONTAINER_ID,
                 "name": str(name),
                 "namespace": str(namespace),

--- a/client/ayon_hiero/plugins/load/load_effects.py
+++ b/client/ayon_hiero/plugins/load/load_effects.py
@@ -2,7 +2,7 @@ import json
 from collections import OrderedDict
 
 from ayon_core.pipeline import (
-    AVALON_CONTAINER_ID,
+    AYON_CONTAINER_ID,
     load,
     get_representation_path,
 )
@@ -288,7 +288,7 @@ class LoadEffects(load.LoaderPlugin):
         data_imprint = {
             object_name: {
                 "schema": "ayon:container-3.0",
-                "id": AVALON_CONTAINER_ID,
+                "id": AYON_CONTAINER_ID,
                 "name": str(name),
                 "namespace": str(namespace),
                 "loader": str(loader),


### PR DESCRIPTION
## Changelog Description

The primary issue addressed is the incorrect assignment of clips to tracks within the Hiero timeline when loading assets using the clip loader. Previously, the loader did not reliably separate each product into a different track, leading to potential conflicts and organization problems within the timeline. This fix ensures that each loaded product and representation is placed on its own dedicated track, improving clarity and manageability.

Additionally, the container schema version was outdated. This update ensures compatibility with newer systems and features.

## Additional info

The fix involves modifying the clip loader logic to check for existing tracks with matching names before creating new ones. This prevents the creation of duplicate tracks and ensures that clips are placed on the correct, pre-existing track if one exists.

## Testing notes:

1.  Load multiple representations of different products into a Hiero project.
2.  Verify that each product and representation is placed on a separate, dedicated track.
3.  Check that the container schema version for loaded assets is "ayon:container-3.0".

Relates to YN-0014