### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_hiero/plugins/create/create_workfile.py
+++ b/client/ayon_hiero/plugins/create/create_workfile.py
@@ -64,6 +64,7 @@ class CreateWorkfile(AutoCreator):
         folder_path = folder_entity["path"]
         task_name = task_entity["name"]
         host_name = self.create_context.host_name
+        variant = self.default_variant
 
         product_name = self.get_product_name(
             project_name=project_name,

--- a/client/ayon_hiero/plugins/create/create_workfile.py
+++ b/client/ayon_hiero/plugins/create/create_workfile.py
@@ -55,21 +55,23 @@ class CreateWorkfile(AutoCreator):
         Returns:
             dict. The data of the instance to be created.
         """
-        project_name = self.create_context.get_current_project_name()
-        folder_path = self.create_context.get_current_folder_path()
-        task_name = self.create_context.get_current_task_name()
-        host_name = self.create_context.host_name
-        variant = self.default_variant
 
+        project_entity = self.create_context.get_current_project_entity()
         folder_entity = self.create_context.get_current_folder_entity()
         task_entity = self.create_context.get_current_task_entity()
 
+        project_name = project_entity["name"]
+        folder_path = folder_entity["path"]
+        task_name = task_entity["name"]
+        host_name = self.create_context.host_name
+
         product_name = self.get_product_name(
-            project_name,
-            folder_entity,
-            task_entity,
-            variant,
-            host_name,
+            project_name=project_name,
+            project_entity=project_entity,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=variant,
+            host_name=host_name,
         )
 
         instance_data = {


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
