### PR TITLE
Enhances clip creation with tokenization

### DIFF
--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -665,11 +665,13 @@ class PublishClip:
     tag_data = {}
 
     types = {
-        "shot": "shot",
-        "folder": "folder",
-        "episode": "episode",
-        "sequence": "sequence",
-        "track": "sequence",
+        "folder1Token": "folder",
+        "folder2Token": "folder",
+        "folder3Token": "folder",
+        "episodeToken": "episode",
+        "sequenceToken": "sequence",
+        "trackToken": "sequence",
+        "shotToken": "shot",
     }
 
     # parents search pattern
@@ -692,9 +694,12 @@ class PublishClip:
         # renameHierarchy
         "hierarchy",
         # hierarchyData
-        "folder", "episode", "sequence", "track", "shot",
+        "folder1Token", "folder2Token", "folder3Token",
+        "episodeToken", "sequenceToken", "trackToken", "shotToken",
         # publish settings
-        "audio", "sourceResolution",
+        "exportAudio", "sourceResolution",
+        # product attributes
+        "productType", "productVariant", "productName",
         # shot attributes
         "workfileFrameStart", "handleStart", "handleEnd",
         # instance attributes data
@@ -794,6 +799,11 @@ class PublishClip:
 
     def _populate_attributes(self):
         """ Populate main object attributes. """
+        # publisher ui attribute inputs or default values if gui was not used
+        def get(key):
+            """Shorthand access for code readability"""
+            return self.pre_create_data.get(key)
+
         # track item frame range and parent track name for vertical sync check
         self.clip_in = int(self.track_item.timelineIn())
         self.clip_out = int(self.track_item.timelineOut())
@@ -803,10 +813,6 @@ class PublishClip:
         log.debug(
             "____ self.shot_num: {}".format(self.shot_num))
 
-        # publisher ui attribute inputs or default values if gui was not used
-        def get(key):
-            """Shorthand access for code readability"""
-            return self.pre_create_data.get(key)
 
         # ui_inputs data or default values if gui was not used
         self.rename = self.pre_create_data.get(
@@ -816,7 +822,7 @@ class PublishClip:
         self.count_from = get("countFrom") or self.count_from_default
         self.count_steps = get("countSteps") or self.count_steps_default
         self.base_product_variant = (
-            get("clipVariant") or self.base_product_variant_default)
+            get("productVariant") or self.base_product_variant_default)
         self.product_type = get("productType") or self.product_type_default
         self.vertical_sync = get("vSyncOn") or self.vertical_sync_default
         self.driving_layer = get("vSyncTrack") or self.driving_layer_default
@@ -826,8 +832,16 @@ class PublishClip:
         self.audio = get("audio") or False
 
         self.hierarchy_data = {
-            key: get(key) or self.track_item_default_data[key]
-            for key in ["folder", "episode", "sequence", "track", "shot"]
+            key.replace("Token", ""): get(key) or self.track_item_default_data[key]
+            for key in [
+                "folder1Token",
+                "folder2Token",
+                "folder3Token",
+                "episodeToken",
+                "sequenceToken",
+                "trackToken",
+                "shotToken"
+            ]
         }
 
         # build product name from layer name
@@ -908,7 +922,7 @@ class PublishClip:
                 hierarchy_data[_key] = self._replace_hash_to_expression(
                     _key, _value)
 
-            # fill up pythonic expresisons in hierarchy data
+            # TODO: fill up pythonic expresisons in hierarchy data
             for _key, _value in hierarchy_data.items():
                 formatted_value = _value.format(**_data)
                 hierarchy_formatting_data[_key] = formatted_value

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -332,7 +332,11 @@ OTIO file.
         tokens_help = """\nUsable tokens:
     {_clip_}: name of used clip
     {_track_}: name of parent track layer
-    {_sequence_}: name of parent sequence (timeline)"""
+    {_sequence_}: name of parent sequence (timeline)
+
+    Python expressions are supported for dynamic values.
+    e.g. `{'_'.join(_clip_.split('_')[:2]).upper()}`
+"""
 
         current_sequence = lib.get_current_sequence()
         if current_sequence is not None:
@@ -366,7 +370,7 @@ OTIO file.
                 label="Shot Parent Hierarchy",
                 tooltip="Parents folder for shot root folder, "
                         "Template filled with *Hierarchy Data* section",
-                default=presets.get("hierarchy", "{folder}/{sequence}"),
+                default=presets.get("hierarchy", "{folder1}/{sequence}"),
             ),
             BoolDef(
                 "clipRename",
@@ -379,7 +383,7 @@ OTIO file.
                 label="Clip Name Template",
                 tooltip="template for creating shot names, used for "
                         "renaming (use rename: on)",
-                default=presets.get("clipName", "{sequence}{shot}"),
+                default=presets.get("clipName", "{shot}"),
             ),
             NumberDef(
                 "countFrom",
@@ -396,39 +400,72 @@ OTIO file.
 
             # hierarchyData
             UILabelDef(
-                label=header_label("Shot Template Keywords")
+                label=header_label("Hierarchy related token definitions")
             ),
             TextDef(
-                "folder",
-                label="{folder}",
+                "folder1Token",
+                label="{folder1}",
                 tooltip="Name of folder used for root of generated shots.\n"
                         f"{tokens_help}",
-                default=presets.get("folder", "shots"),
+                default=presets.get("folder1Token", "shots"),
             ),
             TextDef(
-                "episode",
+                "folder2Token",
+                label="{folder2}",
+                tooltip="Name of additional folder.\n"
+                        f"{tokens_help}",
+                default=presets.get("folder2Token", ""),
+            ),
+            TextDef(
+                "folder3Token",
+                label="{folder3}",
+                tooltip="Name of additional folder.\n"
+                        f"{tokens_help}",
+                default=presets.get("folder3Token", ""),
+            ),
+            TextDef(
+                "episodeToken",
                 label="{episode}",
                 tooltip=f"Name of episode.\n{tokens_help}",
-                default=presets.get("episode", "ep01"),
+                default=presets.get("episodeToken", "ep01"),
             ),
             TextDef(
-                "sequence",
+                "sequenceToken",
                 label="{sequence}",
                 tooltip=f"Name of sequence of shots.\n{tokens_help}",
-                default=presets.get("sequence", "sq01"),
+                default=presets.get("sequenceToken", "sq01"),
             ),
             TextDef(
-                "track",
+                "trackToken",
                 label="{track}",
                 tooltip=f"Name of timeline track.\n{tokens_help}",
-                default=presets.get("track", "{_track_}"),
+                default=presets.get("trackToken", "{_track_}"),
             ),
             TextDef(
-                "shot",
+                "shotToken",
                 label="{shot}",
                 tooltip="Name of shot. '#' is converted to padded number."
                         f"\n{tokens_help}",
-                default=presets.get("shot", "sh###"),
+                default=presets.get("shotToken", "sh###"),
+            ),
+            # verticalSync
+            UILabelDef(
+                label=header_label("Product related token definitions")
+            ),
+            TextDef(
+                "productVariantToken",
+                label="{productVariant}",
+                tooltip="Template for product variant token."
+                        f"\n{tokens_help}",
+                default=presets.get("productVariantToken", "main"),
+            ),
+            TextDef(
+                "productNameToken",
+                label="{productName}",
+                tooltip="Template for product name token."
+                        f"\n{tokens_help}",
+                default=presets.get(
+                    "productNameToken", "{productType}{productVariant}"),
             ),
 
             # verticalSync
@@ -440,7 +477,7 @@ OTIO file.
                 label="Enable Vertical Sync",
                 tooltip="Switch on if you want clips above "
                         "each other to share its attributes",
-                default=presets.get("vSyncOn", True),
+                default=presets.get("vSyncOn", False),
             ),
             EnumDef(
                 "vSyncTrack",
@@ -458,18 +495,37 @@ OTIO file.
                 label=header_label("Publish Settings")
             ),
             EnumDef(
-                "clipVariant",
+                "productVariant",
                 label="Product Variant",
                 tooltip="Chose variant which will be then used for "
                         "product name, if <track_name> "
                         "is selected, name of track layer will be used",
-                items=['<track_name>', 'main', 'bg', 'fg', 'bg', 'animatic'],
+                items=[
+                    {"value": "<track_name>", "label": "Inherited from a track name"},
+                    {"value": "<token>", "label": "From token definition"},
+                    {"value": "main", "label": "Main"},
+                    {"value": "bg", "label": "Bg"},
+                    {"value": "fg", "label": "Fg"},
+                    {"value": "animatic", "label": "Animatic"},
+                ],
+                default=presets.get("productVariant", "<track_name>"),
             ),
             EnumDef(
                 "productType",
                 label="Product Type",
                 tooltip="How the product will be used",
-                items=['plate', 'take'],
+                items=['plate'],
+                default=presets.get("productType", "plate"),
+            ),
+            EnumDef(
+                "productName",
+                label="Product Name",
+                tooltip="How product name will be generated",
+                items=[
+                    {"value": "fromAttributes", "label": "From attributes"},
+                    {"value": "fromTemplate", "label": "From template"}
+                ],
+                default=presets.get("productName", "fromAttributes"),
             ),
             EnumDef(
                 "reviewableSource",
@@ -483,16 +539,16 @@ OTIO file.
                 + gui_tracks,
             ),
             BoolDef(
-                "export_audio",
-                label="Include audio",
+                "exportAudio",
+                label="Include audio product",
                 tooltip="Process subsets with corresponding audio",
-                default=False,
+                default=presets.get("exportAudio", False),
             ),
             BoolDef(
                 "sourceResolution",
                 label="Source resolution",
                 tooltip="Is resolution taken from timeline or source?",
-                default=False,
+                default=presets.get("sourceResolution", False),
             ),
             # shotAttr
             UILabelDef(
@@ -533,7 +589,7 @@ OTIO file.
         for audio_track in self.sequence.audioTracks():
             audio_clips.extend(audio_track.items())
 
-        if not audio_clips and pre_create_data.get("export_audio"):
+        if not audio_clips and pre_create_data.get("exportAudio"):
             raise CreatorError(
                 "You must have audio in your active "
                 "timeline in order to export audio."
@@ -619,7 +675,7 @@ OTIO file.
             # desable audio creator if audio is not enabled
             all_creators[audio_creator_id] = (
                 _instance_data.get("heroTrack", False) and
-                pre_create_data.get("export_audio", False)
+                pre_create_data.get("exportAudio", False)
             )
 
             enabled_creators = tuple(

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -1,9 +1,33 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
+def _product_name_enum():
+    """Return a list of product name options."""
+    return [
+        {"value": "fromAttributes", "label": "From attributes"},
+        {"value": "fromTemplate", "label": "From template"},
+    ]
+
+def _product_variant_enum():
+    """Return a list of product variant options."""
+    return [
+        {"value": "<track_name>", "label": "Inherited from a track name"},
+        {"value": "<token>", "label": "From token definition"},
+        {"value": "main", "label": "Main"},
+        {"value": "bg", "label": "Bg"},
+        {"value": "fg", "label": "Fg"},
+        {"value": "animatic", "label": "Animatic"},
+    ]
+
+def _product_type_enum():
+    """Return a list of product type options."""
+    return [
+        {"value": "plate", "label": "Plate product"},
+    ]
+
 class CreateShotClipModels(BaseSettingsModel):
     hierarchy: str = SettingsField(
-        "{folder}/{sequence}",
+        "{folder1}/{sequence}",
         title="Shot parent hierarchy",
         section="Shot Hierarchy And Rename Settings"
     )
@@ -12,7 +36,7 @@ class CreateShotClipModels(BaseSettingsModel):
         title="Rename clips"
     )
     clipName: str = SettingsField(
-        "{track}{sequence}{shot}",
+        "{shot}",
         title="Clip name template"
     )
     countFrom: int = SettingsField(
@@ -24,26 +48,42 @@ class CreateShotClipModels(BaseSettingsModel):
         title="Stepping number"
     )
 
-    folder: str = SettingsField(
+    folder1Token: str = SettingsField(
         "shots",
-        title="{folder}",
-        section="Shot Template Keywords"
+        title="{folder1}",
+        section="Hierarchy related token definitions"
     )
-    episode: str = SettingsField(
+    folder2Token: str = SettingsField(
+        "",
+        title="{folder2}",
+    )
+    folder3Token: str = SettingsField(
+        "",
+        title="{folder3}",
+    )
+    episodeToken: str = SettingsField(
         "ep01",
         title="{episode}"
     )
-    sequence: str = SettingsField(
+    sequenceToken: str = SettingsField(
         "sq01",
         title="{sequence}"
     )
-    track: str = SettingsField(
+    trackToken: str = SettingsField(
         "{_track_}",
         title="{track}"
     )
-    shot: str = SettingsField(
+    shotToken: str = SettingsField(
         "sh###",
         title="{shot}"
+    )
+    productVariantToken: str = SettingsField(
+        "Main",
+        title="{productVariant}"
+    )
+    productNameToken: str = SettingsField(
+        "{productType}{productVariant}",
+        title="{productName}"
     )
 
     vSyncOn: bool = SettingsField(
@@ -51,7 +91,30 @@ class CreateShotClipModels(BaseSettingsModel):
         title="Enable Vertical Sync",
         section="Vertical Synchronization Of Attributes"
     )
-
+    productVariant: str = SettingsField(
+        "<track_name>",
+        title="Product Variant",
+        enum_resolver=_product_variant_enum,
+        section="Publish Settings"
+    )
+    productType: str = SettingsField(
+        "plate",
+        title="Product Type",
+        enum_resolver=_product_type_enum,
+    )
+    productName: str = SettingsField(
+        "fromAttributes",
+        title="Product Name",
+        enum_resolver=_product_name_enum,
+    )
+    exportAudio: bool = SettingsField(
+        False,
+        title="Include audio product"
+    )
+    sourceResolution: bool = SettingsField(
+        False,
+        title="Source resolution"
+    )
     workfileFrameStart: int = SettingsField(
         1001,
         title="Workfiles Start Frame",
@@ -94,17 +157,26 @@ class CreatorPluginsSettings(BaseSettingsModel):
 DEFAULT_CREATE_SETTINGS = {
     "create": {
         "CreateShotClip": {
-            "hierarchy": "{folder}/{sequence}",
+            "hierarchy": "{folder1}/{sequence}",
             "clipRename": True,
-            "clipName": "{track}{sequence}{shot}",
+            "clipName": "{shot}",
             "countFrom": 10,
             "countSteps": 10,
-            "folder": "shots",
-            "episode": "ep01",
-            "sequence": "sq01",
-            "track": "{_track_}",
-            "shot": "sh###",
+            "folder1Token": "shots",
+            "folder2Token": "",
+            "folder3Token": "",
+            "episodeToken": "ep01",
+            "sequenceToken": "sq01",
+            "trackToken": "{_track_}",
+            "shotToken": "sh###",
+            "productVariantToken": "Main",
+            "productNameToken": "{productType}{productVariant}",
             "vSyncOn": False,
+            "productVariant": "<track_name>",
+            "productType": "plate",
+            "productName": "fromAttributes",
+            "sourceResolution": False,
+            "exportAudio": False,
             "workfileFrameStart": 1001,
             "handleStart": 10,
             "handleEnd": 10


### PR DESCRIPTION
**Changelog Description**

The changes address the need for more customizable and dynamic naming schemes when creating shot clips. By introducing token-based definitions for hierarchy and product names, users can now define naming conventions based on various attributes, such as clip name, track name, sequence name, and custom values. This enhances flexibility and control over the generated shot clip names and their placement within the project hierarchy. The changes introduce new UI elements and settings to manage these token definitions, enabling users to define folder structures, episode names, sequence names, product variants, and product names using a combination of predefined tokens and custom Python expressions. The update solves limitations in the previous naming system, where customization was restricted to a few predefined options.

**Additional info**

The refactoring of the attribute population consolidates the logic for retrieving attribute values, improving code readability. The introduction of token definitions requires updates to the UI and the underlying data structures to accommodate the new settings and configuration options. This involves modifying the Create Shot Clip creator plugin to handle the token-based hierarchy and product name definitions.

**Testing notes:**

1.  Open the Create Shot Clip creator.
2.  Verify the new token definition fields are present in the creator settings.
3.  Modify the token values and confirm the changes are reflected in the created shot clip names and hierarchy.
4.  Test the vertical sync feature to ensure clips are synchronized correctly
5.  Create shot clips with and without audio to verify the audio export functionality is working as expected.
6.  Verify the "Source resolution" setting is correctly applied to the newly created clips.

closes #65
closes #15
related tickets: AY-7859, AY-7012