### PR TITLE
Fix new thumbnail default layer from Hiero 16.0

### DIFF
--- a/client/ayon_hiero/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_hiero/plugins/publish/extract_thumbnail.py
@@ -2,7 +2,6 @@ import os
 import pyblish.api
 
 from ayon_core.pipeline import publish
-from ayon_core.pipeline import PublishError
 
 
 class ExtractThumbnail(publish.Extractor):


### PR DESCRIPTION
## Changelog Description

Foundry has changed the default layer for the thumbnail API:
* used to be `colour` (https://learn.foundry.com/hiero/developers/14.0/HieroPythonDevGuide/api/api_core.html?highlight=layer#hiero.core.SequenceBase.thumbnail)
* it is now `rgb` (https://learn.foundry.com/hiero/developers/latest/HieroPythonDevGuide/api/api_core.html?highlight=layer#hiero.core.SequenceBase.thumbnail)

<img width="2233" height="1024" alt="image" src="https://github.com/user-attachments/assets/5d39a978-54b6-4550-9c3a-c8613fbea1c9" />


The layer thing is something undocumented from the hiero API. Also during my tests I found out clips that contained neither "rgb" or "colour" layers. Not sure how this is possible, but I made sure those track items also handled properly.

## Testing notes:
1. Open new sequence from Hiero 16.0+
2. Ensure new track items thumbnail get extracted from new sequence
3. Ensure new track items thumbnail get extracted from old sequence
4. Ensure incompatible track items are reported with a graceful `PublishError`

closes #98 