### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_hiero/plugins/create/create_editorial_pkg.py
+++ b/client/ayon_hiero/plugins/create/create_editorial_pkg.py
@@ -24,6 +24,7 @@ class CreateEditorialPackage(plugin.HieroCreator):
     identifier = "io.ayon.creators.hiero.editorial_pkg"
     label = "Editorial Package"
     product_type = "editorial_pkg"
+    product_base_type = "editorial_pkg"
     icon = "camera"
     defaults = ["Main"]
 

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -180,6 +180,7 @@ class HieroShotInstanceCreator(_HieroInstanceCreator):
     """Shot product type creator class"""
     identifier = "io.ayon.creators.hiero.shot"
     product_type = "shot"
+    product_base_type = "shot"
     label = "Editorial Shot"
 
     def get_instance_attr_defs(self):
@@ -298,6 +299,7 @@ class EditorialPlateInstanceCreator(_HieroInstanceClipCreatorBase):
     """Plate product type creator class"""
     identifier = "io.ayon.creators.hiero.plate"
     product_type = "plate"
+    product_base_type = "plate"
     label = "Editorial Plate"
 
 
@@ -305,6 +307,7 @@ class EditorialAudioInstanceCreator(_HieroInstanceClipCreatorBase):
     """Audio product type creator class"""
     identifier = "io.ayon.creators.hiero.audio"
     product_type = "audio"
+    product_base_type = "audio"
     label = "Editorial Audio"
 
 
@@ -314,6 +317,7 @@ class CreateShotClip(plugin.HieroCreator):
     identifier = "io.ayon.creators.hiero.clip"
     label = "Create Publishable Clip"
     product_type = "editorial"
+    product_base_type = "editorial"
     icon = "film"
     defaults = ["Main"]
 

--- a/client/ayon_hiero/plugins/create/create_workfile.py
+++ b/client/ayon_hiero/plugins/create/create_workfile.py
@@ -12,6 +12,7 @@ class CreateWorkfile(AutoCreator):
     identifier = "io.ayon.creators.hiero.workfile"
     label = "Workfile"
     product_type = "workfile"
+    product_base_type = "workfile"
     icon = "fa5.file"
 
     default_variant = "Main"


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.
