### PR TITLE
Use layer_name for thumbnail generation instead of hardcoded value.

### DIFF
--- a/client/ayon_hiero/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_hiero/plugins/publish/extract_thumbnail.py
@@ -45,7 +45,7 @@ class ExtractThumbnail(publish.Extractor):
         qimage = None
         for layer_name in ("rgb", "colour"):
             try:
-                qimage = track_item.thumbnail(thumb_frame, "rgb")
+                qimage = track_item.thumbnail(thumb_frame, layer_name)
                 break
 
             except RuntimeError:


### PR DESCRIPTION
## Changelog Description

`layer_name` is now being used for thumbnail generation instead of `rgb` hardcoded value. This allows thumbnail generation in Hiero versions below and above 16.


## Testing notes:

1. Launch Hiero (a version below than 16).
2. Publish a plate (before, make sure plate products are configured to create an ftrack AsserVersion).
3. Check ftrack, created version should have a thumbnail.

