### PR TITLE
Allow clip effects to be published separately from a plate.

### DIFF
--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -284,11 +284,15 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
                         ),
                         disabled=not current_review,
                     ),
-                    BoolDef(
+                    EnumDef(
                         "publish_effects",
                         label="Publish clip effects",
                         tooltip="Discover and publish clip effects",
-                        default=True,
+                        items=[
+                            {"value": "ignore_effects", "label": "Ignore Effects"},
+                            {"value": "publish_effects", "label": "Publish Effects"},
+                            {"value": "publish_only_effects", "label": "Publish Only Effects"},
+                        ],
                     ),
                 ]
             )
@@ -743,6 +747,14 @@ OTIO file.
         Returns:
             CreatedInstance: The newly created instance.
         """
+        # publish effects backward compatibility (YN-0378)
+        creator_attributes = data.get("creator_attributes", {})
+        if isinstance(creator_attributes.get("publish_effects"), bool):
+            if creator_attributes["publish_effects"]:
+                creator_attributes["publish_effects"] = "publish_effects"
+            else:
+                creator_attributes["publish_effects"] = "ignore_effects"
+
         creator = self.create_context.creators[creator_id]
         instance = creator.create(data, None)
         instance.transient_data["track_item"] = track_item

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -749,11 +749,11 @@ OTIO file.
         """
         # publish effects backward compatibility (YN-0378)
         creator_attributes = data.get("creator_attributes", {})
-        if isinstance(creator_attributes.get("publish_effects"), bool):
-            if creator_attributes["publish_effects"]:
-                creator_attributes["publish_effects"] = "publish_effects"
-            else:
-                creator_attributes["publish_effects"] = "ignore_effects"
+        publish_effects = creator_attributes.get("publish_effects")
+        if isinstance(publish_effects, bool):
+            creator_attributes["publish_effects"] = (
+                "publish_effects" if publish_effects else "ignore_effects"
+            )
 
         creator = self.create_context.creators[creator_id]
         instance = creator.create(data, None)

--- a/client/ayon_hiero/plugins/publish/collect_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/collect_clip_effects.py
@@ -67,8 +67,8 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
 
         # Publish effect only mode, disable plate integration.
         if instance.data["creator_attributes"]["publish_effects"] == "publish_only_effects":
-            self.log.debug("Disable instance, only effects are requested.")
-            instance.data["integrate"] = False
+            self.log.debug("Remove instance, only effects are requested.")
+            instance.context.remove(instance)
 
         # skip any without effects
         if not effects:
@@ -155,7 +155,6 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
                 "family": product_type,
                 "families": [product_type],
                 "name": product_name + "_" + data["folderPath"],
-                "integrate": True,
                 "label": "{} - {}".format(
                     data["folderPath"], product_name
                 ),

--- a/client/ayon_hiero/plugins/publish/collect_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/collect_clip_effects.py
@@ -19,7 +19,7 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
             self.log.info("Effects collection/publish is disabled for instance")
             return
 
-        if "audio" in instance.data["productType"]:
+        if instance.data["productType"] == "audio":
             self.log.info("Audio clip, effects publish is only supported for plates.")
             return
 

--- a/client/ayon_hiero/plugins/publish/collect_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/collect_clip_effects.py
@@ -15,22 +15,20 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
     effect_tracks = []
 
     def process(self, instance):
+        if instance.data["creator_attributes"]["publish_effects"] == "ignore_effects":
+            self.log.info("Effects collection/publish is disabled for instance")
+            return
+
+        if "audio" in instance.data["productType"]:
+            self.log.info("Audio clip, effects publish is only supported for plates.")
+            return
+
         product_type = "effect"
         effects = {}
         review = instance.data.get("review")
         review_track_index = instance.context.data.get("reviewTrackIndex")
         track_item = instance.data["trackItem"]
         product_name = instance.data.get("productName")
-
-        if not instance.data["creator_attributes"]["publish_effects"]:
-            self.log.debug(
-                "Effects collection/publish is disabled for %s",
-                product_name,
-            )
-            return
-
-        if "audio" in instance.data["productType"]:
-            return
 
         # frame range
         self.handle_start = instance.data["handleStart"]
@@ -67,8 +65,14 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
                 if effect:
                     effects.update(effect)
 
+        # Publish effect only mode, disable plate integration.
+        if instance.data["creator_attributes"]["publish_effects"] == "publish_only_effects":
+            self.log.debug("Disable instance, only effects are requested.")
+            instance.data["integrate"] = False
+
         # skip any without effects
         if not effects:
+            self.log.info("No effects found for current clip.")
             return
 
         effects.update({"assignTo": product_name})
@@ -142,11 +146,8 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
             product_name += category.capitalize()
 
             # create new instance and inherit data
-            data = {}
-            for key, value in instance.data.items():
-                if "clipEffectItems" in key:
-                    continue
-                data[key] = value
+            data = instance.data.copy()
+            _ = data.pop("clipEffectItems", None)
 
             data.update({
                 "productName": product_name,
@@ -154,6 +155,7 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
                 "family": product_type,
                 "families": [product_type],
                 "name": product_name + "_" + data["folderPath"],
+                "integrate": True,
                 "label": "{} - {}".format(
                     data["folderPath"], product_name
                 ),


### PR DESCRIPTION
## Changelog Description

Fixes: #105 

Provide the plate clip effect option as an enum instead of a boolean with a new "publish only effect" options.
This way plate effects can be published without re-integrating a new plate.

Note: As pointed out in the original issue, the clip effect is tight in to the plate, so we cannot implement it as a completely new instance from the creator.

## Testing notes:
1. Ensure exisiting instances created with the bool value are still working
2. Test out the 3 different flavors:
    - Publish only plate
    - Publish plate + clip effects
    - Publish only clip effects
