### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -581,7 +581,7 @@ def imprint(track_item, data=None):
     Examples:
         data = {
             'folderPath': '/shots/sq020sh0280',
-            'productType': 'render',
+            'productBaseType': 'render',
             'productName': 'productMain'
         }
     """

--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -680,7 +680,6 @@ class PublishClip:
     clip_name_default = "shot_{_trackIndex_:0>3}_{_clipIndex_:0>4}"
     base_product_variant_default = "<track_name>"
     review_source_default = None
-    product_type_default = "plate"
     count_from_default = 10
     count_steps_default = 10
     vertical_sync_default = False
@@ -816,7 +815,7 @@ class PublishClip:
         self.count_steps = get("countSteps") or self.count_steps_default
         self.base_product_variant = (
             get("clipVariant") or self.base_product_variant_default)
-        self.product_type = get("productType") or self.product_type_default
+        self.product_type = get("plate_product_type") or "plate"
         self.vertical_sync = get("vSyncOn") or self.vertical_sync_default
         self.driving_layer = get("vSyncTrack") or self.driving_layer_default
         self.driving_layer = self.driving_layer.replace(" ", "_")
@@ -835,7 +834,7 @@ class PublishClip:
         else:
             self.variant = self.base_product_variant
 
-        # create product for publishing
+        # create product name for publishing
         self.product_name = f"{self.product_type}{self.variant.capitalize()}"
 
     def _replace_hash_to_expression(self, name, text):
@@ -1027,6 +1026,7 @@ class PublishClip:
             "hierarchyData": hierarchy_formatting_data,
             "productName": self.product_name,
             "productType": self.product_type,
+            "productBaseType": "plate",
             "variant": self.variant,
         }
 

--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -626,11 +626,6 @@ class HieroCreator(Creator):
     """
     settings_category = "hiero"
 
-    def __init__(self, *args, **kwargs):
-        super(Creator, self).__init__(*args, **kwargs)
-        self.presets = get_current_project_settings()[
-            "hiero"]["create"].get(self.__class__.__name__, {})
-
     def create(self, product_name, instance_data, pre_create_data):
         """Prepare data for new instance creation.
 

--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -15,7 +15,6 @@ from ayon_core.pipeline import (
     LoaderPlugin,
 )
 from ayon_core.pipeline.load import get_representation_path_from_context
-from ayon_core.settings import get_current_project_settings
 
 from . import lib
 

--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -610,6 +610,7 @@ class HiddenHieroCreator(HiddenCreator):
     """HiddenCreator class wrapper
     """
     settings_category = "hiero"
+    skip_discovery = True
 
     def collect_instances(self):
         pass
@@ -625,6 +626,7 @@ class HieroCreator(Creator):
     """Creator class wrapper
     """
     settings_category = "hiero"
+    skip_discovery = True
 
     def create(self, product_name, instance_data, pre_create_data):
         """Prepare data for new instance creation.

--- a/client/ayon_hiero/plugins/create/create_editorial_pkg.py
+++ b/client/ayon_hiero/plugins/create/create_editorial_pkg.py
@@ -23,8 +23,8 @@ class CreateEditorialPackage(plugin.HieroCreator):
 
     identifier = "io.ayon.creators.hiero.editorial_pkg"
     label = "Editorial Package"
-    product_type = "editorial_pkg"
     product_base_type = "editorial_pkg"
+    product_type = product_base_type
     icon = "camera"
     defaults = ["Main"]
 

--- a/client/ayon_hiero/plugins/create/create_editorial_pkg.py
+++ b/client/ayon_hiero/plugins/create/create_editorial_pkg.py
@@ -84,11 +84,15 @@ class CreateEditorialPackage(plugin.HieroCreator):
             "review": pre_create_data["review"]
         }
 
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         new_instance = CreatedInstance(
-            self.product_type,
-            product_name,
-            instance_data,
-            self
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
         self._add_instance_to_context(new_instance)
 
@@ -107,11 +111,15 @@ class CreateEditorialPackage(plugin.HieroCreator):
                     continue
 
                 instance_data = tags.get_tag_data(item)
+                product_type = instance_data.get("productType")
+                if not product_type:
+                    product_type = self.product_base_type
                 instance = CreatedInstance(
-                    self.product_type,
-                    instance_data["productName"],
-                    instance_data,
-                    self
+                    product_base_type=self.product_base_type,
+                    product_type=product_type,
+                    product_name=instance_data["productName"],
+                    data=instance_data,
+                    creator=self,
                 )
                 self._add_instance_to_context(instance)
 

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -631,11 +631,10 @@ OTIO file.
                 pre_create_data.get("export_audio", False)
             )
 
-            enabled_creators = tuple(
-                cre for cre, enabled in all_creators.items() if enabled
-            )
             clip_instances = {}
-            for creator_id in enabled_creators:
+            for creator_id, enabled in all_creators.items():
+                if not enabled:
+                    continue
                 creator = self.create_context.creators[creator_id]
                 sub_instance_data = copy.deepcopy(_instance_data)
                 creator_attributes = sub_instance_data.setdefault(

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -110,7 +110,7 @@ class _HieroInstanceCreator(plugin.HiddenHieroCreator):
             )
         super()._add_instance_to_context(instance)
 
-    def create(self, instance_data, _):
+    def create(self, instance_data):
         """Return a new CreateInstance for new shot from Hiero.
 
         Args:
@@ -530,10 +530,8 @@ OTIO file.
             ),
         ]
 
-    def create(self, subset_name, instance_data, pre_create_data):
-        super(CreateShotClip, self).create(subset_name,
-                                           instance_data,
-                                           pre_create_data)
+    def create(self, product_name, instance_data, pre_create_data):
+        super().create(product_name, instance_data, pre_create_data)
 
         if len(self.selected) < 1:
             return
@@ -721,7 +719,7 @@ OTIO file.
                     if sub_instance_data.get("reviewableSource"):
                         creator_attributes["review"] = True
 
-                instance = creator.create(sub_instance_data, None)
+                instance = creator.create(sub_instance_data)
                 instance.transient_data["track_item"] = track_item
                 self._add_instance_to_context(instance)
                 instance_data_to_store = instance.data_to_store()
@@ -752,7 +750,7 @@ OTIO file.
             CreatedInstance: The newly created instance.
         """
         creator = self.create_context.creators[creator_id]
-        instance = creator.create(data, None)
+        instance = creator.create(data)
         instance.transient_data["track_item"] = track_item
         self._add_instance_to_context(instance)
         instances.append(instance)
@@ -872,7 +870,7 @@ OTIO file.
 
         shot_creator_id = "io.ayon.creators.hiero.shot"
         creator = self.create_context.creators[shot_creator_id]
-        instance = creator.create(sub_instance_data, None)
+        instance = creator.create(sub_instance_data)
         instance.transient_data["track_item"] = track_item
         self._add_instance_to_context(instance)
         clip_instances[shot_creator_id] = instance.data_to_store()
@@ -906,7 +904,7 @@ OTIO file.
                 }
             )
 
-            instance = creator.create(sub_instance_data, None)
+            instance = creator.create(sub_instance_data)
             instance.transient_data["track_item"] = track_item
             self._add_instance_to_context(instance)
             clip_instances[sub_creator_id] = instance.data_to_store()

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -119,12 +119,14 @@ class _HieroInstanceCreator(plugin.HiddenHieroCreator):
         Return:
             CreatedInstance: The created instance object for the new shot.
         """
-        instance_data.update({
-            "newHierarchyIntegration": True,
-        })
-
+        instance_data["newHierarchyIntegration"] = True
+        product_type = instance_data.get("productType")
         new_instance = CreatedInstance(
-            self.product_type, instance_data["productName"], instance_data, self
+            product_base_type=self.product_base_type,
+            product_type=product_type or self.product_base_type,
+            product_name=instance_data["productName"],
+            data=instance_data,
+            creator=self,
         )
         self._add_instance_to_context(new_instance)
         new_instance.transient_data["has_promised_context"] = True
@@ -206,7 +208,7 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
         self.create_context.add_value_changed_callback(self._on_value_change)
 
     def _on_value_change(self, event):
-        if self.product_type != "plate":
+        if self.product_base_type != "plate":
             return
 
         for item in event["changes"]:
@@ -255,7 +257,7 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
             )
         ]
 
-        if self.product_type in ("audio", "plate"):
+        if self.product_base_type in ("audio", "plate"):
             instance_attributes.append(
                 BoolDef(
                     "review",
@@ -265,7 +267,7 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
                 )
             )
 
-        if self.product_type == "plate":
+        if self.product_base_type == "plate":
             # Review track visibility
             current_review = instance.creator_attributes.get("review", False)
 
@@ -355,19 +357,20 @@ OTIO file.
         else:
             gui_tracks = []
 
-        # Project settings might be applied to this creator via
-        # the inherited `Creator.apply_settings`
-        presets = self.presets
+        plate_product_type_items = self.presets["plate_product_type_items"]
+        if not plate_product_type_items:
+            plate_product_type_items = ["plate"]
 
         return [
-
-            BoolDef("use_selection",
-                    label="Use only selected clip(s).",
-                    tooltip=(
-                        "When enabled it restricts create process "
-                        "to selected clips."
-                    ),
-                    default=True),
+            BoolDef(
+                "use_selection",
+                label="Use only selected clip(s).",
+                tooltip=(
+                    "When enabled it restricts create process "
+                    "to selected clips."
+                ),
+                default=True
+            ),
 
             # renameHierarchy
             UILabelDef(
@@ -378,32 +381,32 @@ OTIO file.
                 label="Shot Parent Hierarchy",
                 tooltip="Parents folder for shot root folder, "
                         "Template filled with *Hierarchy Data* section",
-                default=presets.get("hierarchy", "{folder}/{sequence}"),
+                default=self.presets["hierarchy"],
             ),
             BoolDef(
                 "clipRename",
                 label="Rename clips",
                 tooltip="Renaming selected clips on fly",
-                default=presets.get("clipRename", False),
+                default=self.presets["clipRename"],
             ),
             TextDef(
                 "clipName",
                 label="Clip Name Template",
                 tooltip="template for creating shot names, used for "
                         "renaming (use rename: on)",
-                default=presets.get("clipName", "{sequence}{shot}"),
+                default=self.presets["clipName"],
             ),
             NumberDef(
                 "countFrom",
                 label="Count sequence from",
                 tooltip="Set where the sequence number starts from",
-                default=presets.get("countFrom", 10),
+                default=self.presets["countFrom"],
             ),
             NumberDef(
                 "countSteps",
                 label="Stepping number",
                 tooltip="What number is adding every new step",
-                default=presets.get("countSteps", 10),
+                default=self.presets["countSteps"],
             ),
 
             # hierarchyData
@@ -415,32 +418,32 @@ OTIO file.
                 label="{folder}",
                 tooltip="Name of folder used for root of generated shots.\n"
                         f"{tokens_help}",
-                default=presets.get("folder", "shots"),
+                default=self.presets["folder"],
             ),
             TextDef(
                 "episode",
                 label="{episode}",
                 tooltip=f"Name of episode.\n{tokens_help}",
-                default=presets.get("episode", "ep01"),
+                default=self.presets["episode"],
             ),
             TextDef(
                 "sequence",
                 label="{sequence}",
                 tooltip=f"Name of sequence of shots.\n{tokens_help}",
-                default=presets.get("sequence", "sq01"),
+                default=self.presets["sequence"],
             ),
             TextDef(
                 "track",
                 label="{track}",
                 tooltip=f"Name of timeline track.\n{tokens_help}",
-                default=presets.get("track", "{_track_}"),
+                default=self.presets["track"],
             ),
             TextDef(
                 "shot",
                 label="{shot}",
                 tooltip="Name of shot. '#' is converted to padded number."
                         f"\n{tokens_help}",
-                default=presets.get("shot", "sh###"),
+                default=self.presets["shot"],
             ),
 
             # verticalSync
@@ -452,7 +455,7 @@ OTIO file.
                 label="Enable Vertical Sync",
                 tooltip="Switch on if you want clips above "
                         "each other to share its attributes",
-                default=presets.get("vSyncOn", True),
+                default=self.presets["vSyncOn"],
             ),
             EnumDef(
                 "vSyncTrack",
@@ -462,7 +465,7 @@ OTIO file.
                 items=(
                     gui_tracks or [
                         {"value": None, "label": "< nothing to select> "}
-                        ]
+                    ]
                 ),
             ),
             # publishSettings
@@ -478,10 +481,10 @@ OTIO file.
                 items=['<track_name>', 'main', 'bg', 'fg', 'bg', 'animatic'],
             ),
             EnumDef(
-                "productType",
-                label="Product Type",
+                "plate_product_type",
+                label="Plate Product Type",
                 tooltip="How the product will be used",
-                items=['plate', 'take'],
+                items=plate_product_type_items,
             ),
             EnumDef(
                 "reviewableSource",
@@ -491,13 +494,12 @@ OTIO file.
                 items=[
                     {"value": None, "label": "< none >"},
                     {"value": "clip_media", "label": "[ Clip's media ]"},
-                ]
-                + gui_tracks,
+                ] + gui_tracks,
             ),
             BoolDef(
                 "export_audio",
                 label="Include audio",
-                tooltip="Process subsets with corresponding audio",
+                tooltip="Process products with corresponding audio",
                 default=False,
             ),
             BoolDef(
@@ -514,19 +516,19 @@ OTIO file.
                 "workfileFrameStart",
                 label="Workfiles Start Frame",
                 tooltip="Set workfile starting frame number",
-                default=presets.get("workfileFrameStart", 1001),
+                default=self.presets["workfileFrameStart"],
             ),
             NumberDef(
                 "handleStart",
                 label="Handle start (head)",
                 tooltip="Handle at start of clip",
-                default=presets.get("handleStart", 0),
+                default=self.presets["handleStart"],
             ),
             NumberDef(
                 "handleEnd",
                 label="Handle end (tail)",
                 tooltip="Handle at end of clip",
-                default=presets.get("handleEnd", 0),
+                default=self.presets["handleEnd"],
             ),
         ]
 
@@ -563,9 +565,9 @@ OTIO file.
 
         sorted_selected_track_items.extend(unsorted_selected_track_items)
 
-        shot_creator_id = "io.ayon.creators.hiero.shot"
-        audio_creator_id = "io.ayon.creators.hiero.audio"
-        plate_creator_id = "io.ayon.creators.hiero.plate"
+        shot_creator_id = HieroShotInstanceCreator.identifier
+        audio_creator_id = EditorialAudioInstanceCreator.identifier
+        plate_creator_id = EditorialPlateInstanceCreator.identifier
 
         # detect enabled creators for review, plate and audio
         all_creators = {
@@ -682,7 +684,10 @@ OTIO file.
                 # metadata recollection as publish time.
                 elif creator_id == plate_creator_id:
                     parenting_data = shot_instances[shot_creator_id]
+                    product_type = pre_create_data.get("plate_product_type")
                     sub_instance_data.update({
+                        "productType": product_type or "plate",
+                        "productBaseType": "plate",
                         "parent_instance_id": parenting_data["instance_id"],
                         "label": (
                             f"{sub_instance_data['folderPath']} "
@@ -700,6 +705,7 @@ OTIO file.
 
                 elif creator_id == audio_creator_id:
                     sub_instance_data["variant"] = "main"
+                    sub_instance_data["productBaseType"] = "audio"
                     sub_instance_data["productType"] = "audio"
                     sub_instance_data["productName"] = "audioMain"
 
@@ -779,8 +785,13 @@ OTIO file.
             "extract_audio": False,
         }
         for create_attr in self.get_pre_create_attr_defs():
-            if isinstance(create_attr.key, str):
-                instance_data[create_attr.key] = create_attr.default
+            key = create_attr.key
+            if not isinstance(key, str):
+                continue
+
+            if key == "plate_product_type":
+                key = "productType"
+            instance_data[key] = create_attr.default
 
         required_key_mapping = {
             "tag.audio": ("extract_audio", bool),
@@ -868,7 +879,7 @@ OTIO file.
             }
         })
 
-        shot_creator_id = "io.ayon.creators.hiero.shot"
+        shot_creator_id = HieroShotInstanceCreator.identifier
         creator = self.create_context.creators[shot_creator_id]
         instance = creator.create(sub_instance_data)
         instance.transient_data["track_item"] = track_item
@@ -879,11 +890,13 @@ OTIO file.
         # Create plate/audio instance
         if instance_data["extract_audio"]:
             sub_creators = (
-                "io.ayon.creators.hiero.plate",
-                "io.ayon.creators.hiero.audio"
+                EditorialPlateInstanceCreator.identifier,
+                EditorialAudioInstanceCreator.identifier
             )
         else:
-            sub_creators = ("io.ayon.creators.hiero.plate",)
+            sub_creators = (
+                EditorialPlateInstanceCreator.identifier,
+            )
 
         for sub_creator_id in sub_creators:
             sub_instance_data = instance_data.copy()
@@ -927,9 +940,14 @@ OTIO file.
         else:
             all_video_tracks = []
 
-        create_settings = self.project_settings["hiero"]["create"]
-        collect_settings = create_settings.get("CollectShotClip", {})
-        restrict_to_selection = collect_settings.get("collectSelectedInstance", False)
+        restrict_to_selection = (
+            self.project_settings
+            ["hiero"]
+            ["create"]
+            ["CollectShotClip"]
+            ["collectSelectedInstance"]
+        )
+
         current_selection = [
             item for item in lib.get_timeline_selection()
             if isinstance(item, hiero.core.TrackItem)  # get only clips
@@ -968,13 +986,20 @@ OTIO file.
             # Ensure that parent shot instance are enabled.
             # This can happen when vertical_align is enabled
             # but hero track is not part of the collected clips.
-            all_shot_ids = [inst.id for inst in instances if inst.data["productType"] == "shot"]
+            all_shot_ids = {
+                inst.id
+                for inst in instances
+                if inst.data["productBaseType"] == "shot"
+            }
 
             for inst in instances:
                 if inst.id in all_shot_ids:
                     continue
 
-                elif inst.data["active"] and inst.data["parent_instance_id"] not in all_shot_ids:
+                if (
+                    inst.data["active"]
+                    and inst.data["parent_instance_id"] not in all_shot_ids
+                ):
                     raise CreatorError(
                         "Incomplete selection: please select hero track"
                         f' for {inst.data["label"]} instance.'

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -485,7 +485,7 @@ OTIO file.
                 "plate_product_type",
                 label="Plate Product Type",
                 tooltip="How the product will be used",
-                items=plate_product_type_items,
+                items=plate_product_types,
             ),
             EnumDef(
                 "reviewableSource",

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -328,7 +328,6 @@ Publishing clips/plate, audio for new shots to project
 or updating already created from Hiero. Publishing will create
 OTIO file.
 """
-    create_allow_thumbnail = False
     presets = {}
 
     def apply_settings(self, project_settings):
@@ -641,7 +640,6 @@ OTIO file.
                 sub_instance_data = copy.deepcopy(_instance_data)
                 creator_attributes = sub_instance_data.setdefault(
                     "creator_attributes", {})
-                shot_folder_path = sub_instance_data["folderPath"]
 
                 # Shot creation
                 if creator_id == shot_creator_id:

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -3,14 +3,12 @@ import json
 
 from ayon_hiero.api import constants, plugin, lib, tags
 
-from ayon_core.pipeline.create import CreatorError, CreatedInstance
 from ayon_core.lib import BoolDef, EnumDef, TextDef, UILabelDef, NumberDef
-
-try:
-    from ayon_core.pipeline.create import ParentFlags
-except ImportError:
-    # Parenting was added with 'https://github.com/ynput/ayon-core/pull/1395'
-    ParentFlags = None
+from ayon_core.pipeline.create import (
+    CreatorError,
+    CreatedInstance,
+    ParentFlags,
+)
 
 import hiero
 

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -651,6 +651,7 @@ OTIO file.
                         {
                             "variant": "main",
                             "productType": "shot",
+                            "productBaseType": "shot",
                             "productName": "shotMain",
                             "label": (
                                 f"{sub_instance_data['folderPath']} shotMain"),

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -180,8 +180,8 @@ class _HieroInstanceCreator(plugin.HiddenHieroCreator):
 class HieroShotInstanceCreator(_HieroInstanceCreator):
     """Shot product type creator class"""
     identifier = "io.ayon.creators.hiero.shot"
-    product_type = "shot"
     product_base_type = "shot"
+    product_type = product_base_type
     label = "Editorial Shot"
 
     def get_instance_attr_defs(self):
@@ -300,16 +300,16 @@ class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
 class EditorialPlateInstanceCreator(_HieroInstanceClipCreatorBase):
     """Plate product type creator class"""
     identifier = "io.ayon.creators.hiero.plate"
-    product_type = "plate"
     product_base_type = "plate"
+    product_type = product_base_type
     label = "Editorial Plate"
 
 
 class EditorialAudioInstanceCreator(_HieroInstanceClipCreatorBase):
     """Audio product type creator class"""
     identifier = "io.ayon.creators.hiero.audio"
-    product_type = "audio"
     product_base_type = "audio"
+    product_type = product_base_type
     label = "Editorial Audio"
 
 
@@ -318,8 +318,8 @@ class CreateShotClip(plugin.HieroCreator):
 
     identifier = "io.ayon.creators.hiero.clip"
     label = "Create Publishable Clip"
-    product_type = "editorial"
     product_base_type = "editorial"
+    product_type = product_base_type
     icon = "film"
     defaults = ["Main"]
 

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -327,6 +327,12 @@ or updating already created from Hiero. Publishing will create
 OTIO file.
 """
     create_allow_thumbnail = False
+    presets = {}
+
+    def apply_settings(self, project_settings):
+        self.presets = (
+            project_settings["hiero"]["create"][self.__class__.__name__]
+        )
 
     def get_pre_create_attr_defs(self):
 

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -97,6 +97,7 @@ CLIP_ATTR_DEFS = [
 class _HieroInstanceCreator(plugin.HiddenHieroCreator):
     """Wrapper class for clip types products.
     """
+    skip_discovery = True
 
     def _add_instance_to_context(self, instance):
         parent_id = instance.get("parent_instance_id")
@@ -199,6 +200,7 @@ class HieroShotInstanceCreator(_HieroInstanceCreator):
 class _HieroInstanceClipCreatorBase(_HieroInstanceCreator):
     """ Base clip product creator.
     """
+    skip_discovery = True
 
     def register_callbacks(self):
         self.create_context.add_value_changed_callback(self._on_value_change)

--- a/client/ayon_hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_hiero/plugins/create/create_shot_clip.py
@@ -358,9 +358,9 @@ OTIO file.
         else:
             gui_tracks = []
 
-        plate_product_type_items = self.presets["plate_product_type_items"]
-        if not plate_product_type_items:
-            plate_product_type_items = ["plate"]
+        plate_product_types = self.presets["plate_product_types"]
+        if not plate_product_types:
+            plate_product_types = ["plate"]
 
         return [
             BoolDef(

--- a/client/ayon_hiero/plugins/create/create_workfile.py
+++ b/client/ayon_hiero/plugins/create/create_workfile.py
@@ -82,14 +82,6 @@ class CreateWorkfile(AutoCreator):
             "variant": variant,
             "productName": product_name,
         }
-        instance_data.update(self.get_dynamic_data(
-            variant,
-            task_name,
-            folder_entity,
-            project_name,
-            host_name,
-            False,
-        ))
 
         return instance_data
 

--- a/client/ayon_hiero/plugins/create/create_workfile.py
+++ b/client/ayon_hiero/plugins/create/create_workfile.py
@@ -74,6 +74,7 @@ class CreateWorkfile(AutoCreator):
             task_entity=task_entity,
             variant=variant,
             host_name=host_name,
+            product_type=self.product_type,
         )
 
         instance_data = {
@@ -94,7 +95,12 @@ class CreateWorkfile(AutoCreator):
         self.log.info("Auto-creating workfile instance...")
         data = self._create_new_instance()
         current_instance = CreatedInstance(
-            self.product_type, data["productName"], data, self)
+            product_base_type=self.product_base_type,
+            product_type=self.product_type,
+            product_name=data["productName"],
+            data=data,
+            creator=self,
+        )
         self._add_instance_to_context(current_instance)
 
     def collect_instances(self):
@@ -103,8 +109,13 @@ class CreateWorkfile(AutoCreator):
         if not data:
             return
 
+        product_type = data.get("productType")
         instance = CreatedInstance(
-            self.product_type, data["productName"], data, self
+            product_base_type=self.product_base_type,
+            product_type=product_type or self.product_base_type,
+            product_name=data["productName"],
+            data=data,
+            creator=self,
         )
         self._add_instance_to_context(instance)
 

--- a/client/ayon_hiero/plugins/create/create_workfile.py
+++ b/client/ayon_hiero/plugins/create/create_workfile.py
@@ -11,8 +11,8 @@ class CreateWorkfile(AutoCreator):
 
     identifier = "io.ayon.creators.hiero.workfile"
     label = "Workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     icon = "fa5.file"
 
     default_variant = "Main"

--- a/client/ayon_hiero/plugins/create/create_workfile.py
+++ b/client/ayon_hiero/plugins/create/create_workfile.py
@@ -86,7 +86,7 @@ class CreateWorkfile(AutoCreator):
 
         return instance_data
 
-    def create(self, options=None):
+    def create(self):
         """Auto-create an instance by default."""
         instance_data = self.load_instance_data()
         if instance_data:

--- a/client/ayon_hiero/plugins/load/load_clip.py
+++ b/client/ayon_hiero/plugins/load/load_clip.py
@@ -15,7 +15,8 @@ class LoadClip(phiero.SequenceLoader):
     during conforming to project
     """
 
-    product_types = {"render2d", "source", "plate", "render", "review"}
+    product_base_types = {"render2d", "source", "plate", "render", "review"}
+    product_types = product_base_types
     representations = {"*"}
     extensions = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)

--- a/client/ayon_hiero/plugins/load/load_editorial_package.py
+++ b/client/ayon_hiero/plugins/load/load_editorial_package.py
@@ -16,7 +16,8 @@ import hiero.core
 class LoadEditorialPackage(load.LoaderPlugin):
     """Load editorial package to timeline.
     """
-    product_types = {"editorial_pkg"}
+    product_base_types = {"editorial_pkg"}
+    product_types = product_base_types
 
     representations = {"*"}
     extensions = {"otio"}

--- a/client/ayon_hiero/plugins/load/load_effects.py
+++ b/client/ayon_hiero/plugins/load/load_effects.py
@@ -13,7 +13,8 @@ from ayon_core.lib import Logger
 class LoadEffects(load.LoaderPlugin):
     """Loading colorspace soft effect exported from nukestudio"""
 
-    product_types = {"effect"}
+    product_base_types = {"effect"}
+    product_types = product_base_types
     representations = {"*"}
     extension = {"json"}
 

--- a/client/ayon_hiero/plugins/publish/collect_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/collect_clip_effects.py
@@ -15,12 +15,12 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
     effect_tracks = []
 
     def process(self, instance):
-        product_type = "effect"
+        product_base_type = "effect"
         effects = {}
         review = instance.data.get("review")
         review_track_index = instance.context.data.get("reviewTrackIndex")
         track_item = instance.data["trackItem"]
-        product_name = instance.data.get("productName")
+        product_name = instance.data["productName"]
 
         if not instance.data["creator_attributes"]["publish_effects"]:
             self.log.debug(
@@ -29,7 +29,7 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
             )
             return
 
-        if "audio" in instance.data["productType"]:
+        if "audio" in instance.data["productBaseType"]:
             return
 
         # frame range
@@ -150,9 +150,11 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
 
             data.update({
                 "productName": product_name,
-                "productType": product_type,
-                "family": product_type,
-                "families": [product_type],
+                # TODO add support for product types
+                "productType": product_base_type,
+                "productBaseType": product_base_type,
+                "family": product_base_type,
+                "families": [product_base_type],
                 "name": product_name + "_" + data["folderPath"],
                 "label": "{} - {}".format(
                     data["folderPath"], product_name

--- a/client/ayon_hiero/plugins/publish/collect_frame_tag_instances.py
+++ b/client/ayon_hiero/plugins/publish/collect_frame_tag_instances.py
@@ -11,7 +11,7 @@ class CollectFrameTagInstances(pyblish.api.ContextPlugin):
 
     Tag is expected to have metadata:
     {
-        "productType": "frame"
+        "productBaseType": "frame"
         "productName": "main"
     }
     """
@@ -70,7 +70,6 @@ class CollectFrameTagInstances(pyblish.api.ContextPlugin):
         return data
 
     def _create_frame_product_data_sequence(self, context):
-
         sequence_tags = []
         sequence = context.data["activeTimeline"]
 
@@ -90,16 +89,14 @@ class CollectFrameTagInstances(pyblish.api.ContextPlugin):
             if not tag_data:
                 continue
 
-            product_type = tag_data.get("productType")
-            if product_type is None:
-                product_type = tag_data.get("family")
-            if not product_type:
-                continue
+            product_base_types = tag_data.get("productBaseType")
+            if not product_base_types:
+                product_base_types = tag_data.get("productType")
+                if not product_base_types:
+                    product_base_types = tag_data.get("family")
 
-            if product_type != "frame":
-                continue
-
-            sequence_tags.append(tag_data)
+            if product_base_types == "frame":
+                sequence_tags.append(tag_data)
 
         self.log.debug("__ sequence_tags: {}".format(
             pformat(sequence_tags)
@@ -133,15 +130,17 @@ class CollectFrameTagInstances(pyblish.api.ContextPlugin):
 
     def _create_instances(self, product_data):
         # create instance per product
-        product_type = "image"
+        product_base_type = "image"
         for product_name, product_data in product_data.items():
             name = "frame" + product_name.title()
             data = {
                 "name": name,
                 "label": "{} {}".format(name, product_data["frames"]),
-                "productType": product_type,
-                "family": product_type,
-                "families": [product_type, "frame"],
+                # TODO add product types support
+                "productType": product_base_type,
+                "productBaseType": product_base_type,
+                "family": product_base_type,
+                "families": [product_base_type, "frame"],
                 "folderPath": product_data["folderPath"],
                 "productName": name,
                 "format": product_data["format"],

--- a/client/ayon_hiero/plugins/publish/collect_tag_tasks.py
+++ b/client/ayon_hiero/plugins/publish/collect_tag_tasks.py
@@ -16,17 +16,20 @@ class CollectClipTagTasks(api.InstancePlugin):
 
         tasks = {}
         for tag in tags:
-
             t_metadata = dict(tag.metadata())
             if t_metadata.get("tag.json_metadata"):
                 metadata = json.loads(t_metadata["tag.json_metadata"])
-                product_type = metadata.get("productType")
-                if product_type == "task":
+                product_base_type = metadata.get("productBaseType")
+                if not product_base_type:
+                    product_base_type = metadata.get("productType")
+
+                if product_base_type == "task":
                     task_type = metadata.get("type")
                     task_name = t_metadata.get("tag.label", "")
                     tasks[task_name] = {"type": task_type}
             else:
                 # backward compatiblity for older tags
+                # NOTE 'productBaseType' was added after 'json_metadata'
                 t_product_type = t_metadata.get("tag.productType")
                 if t_product_type is None:
                     t_product_type = t_metadata.get("tag.family", "")

--- a/client/ayon_hiero/plugins/publish/extract_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/extract_clip_effects.py
@@ -21,7 +21,7 @@ class ExtractClipEffects(publish.Extractor):
             return
 
         product_name = instance.data.get("productName")
-        product_type = instance.data["productType"]
+        product_base_type = instance.data["productBaseType"]
 
         self.log.debug("creating staging dir")
         staging_dir = self.staging_dir(instance)
@@ -67,9 +67,7 @@ class ExtractClipEffects(publish.Extractor):
         version_data.update({
             "colorSpace": item.sourceMediaColourTransform(),
             "colorspaceScript": instance.context.data["colorspace"],
-            "families": [product_type, "plate"],
-            # TODO find out if 'subset' is needed (and 'productName')
-            "subset": product_name,
+            "families": [product_base_type, "plate"],
             "productName": product_name,
             "fps": instance.context.data["fps"]
         })
@@ -78,7 +76,7 @@ class ExtractClipEffects(publish.Extractor):
         representation = {
             'files': file,
             'stagingDir': staging_dir,
-            'name': product_type + ext.title(),
+            'name': product_base_type + ext.title(),
             'ext': ext
         }
         instance.data["representations"].append(representation)

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -47,9 +47,9 @@ class CreateShotClipModels(BaseSettingsModel):
     )
 
     plate_product_types: list[str] = SettingsField(
-        "plate_product_types",
         default_factory=list,
-        title="Plate product type",
+        title="Plate Product types",
+        description="Optional list of product types for plate products."
     )
 
     vSyncOn: bool = SettingsField(

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -46,6 +46,12 @@ class CreateShotClipModels(BaseSettingsModel):
         title="{shot}"
     )
 
+    plate_product_types: list[str] = SettingsField(
+        "plate_product_types",
+        default_factory=list,
+        title="Plate product type",
+    )
+
     vSyncOn: bool = SettingsField(
         False,
         title="Enable Vertical Sync",


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Codebase of Hierp addon is fully using product base type as "pipeline" type and product type as an alias. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

Shot create plugin have option to define custom product types for plate instances. The rest is missing at this moment because I was not able to find out how the wheel works

Side changes:
- Moved override of `apply_settings` to the only create plugin which actually uses it.
- Use 'product' instead of 'subset'.
- Marked base classes to be skipped during discovery.
- Don't use "safe getters" for settings to make sure settings are actually used.

## Testing notes:
This is untested PR from my side, please make sure it is fully reviewed. I have no idea how things really do work and most probably failed at few places.
### Basics
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Upload the addon to server to use new settings model.
3. Existing workfiles should load up and should be possible to publish.
4. Creating new instances should work as expected.

### Product types
1. Define product types for plate and audio in settings.
2. Publisher should show selection of them in pre-create attributes.
3. Create them.
5. Product name should use the product type in name (if template defines that).
6. Publish the instances.
7. Loader tool should show the product type and product base type in UI.