### PR TITLE
Exclude "subtracks" from deepcopy in collect_clip_effects

### DIFF
--- a/client/ayon_hiero/plugins/publish/collect_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/collect_clip_effects.py
@@ -154,6 +154,7 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
                     "clipEffectItems",
                     "trackItem",
                     "transientData",
+                    "subtracks"
                 )
             }
             data = copy.deepcopy(inherit_data)


### PR DESCRIPTION
## Changelog Description

This PR fixes #117 

'Subtracks' key was not being skipped when adding data to `inherit_data` causing `copy.deepcopy(inherit_data)` to fail because it contained items (`effectTrackItems`) that cannot be serialized. 

## Testing notes:
1. Launch Hiero, create a clip and add a soft-effect
2. Publish using `publish effects only` or `publish effects` options. Collector should not fail and expected products should be published.
