### PR TITLE
Replace qargparse with attribute definitions

### DIFF
--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -7,9 +7,8 @@ from typing import Dict, Any, Optional
 import hiero
 
 from qtpy import QtWidgets, QtCore
-import qargparse
 
-from ayon_core.lib import Logger
+from ayon_core.lib import Logger, BoolDef, EnumDef
 from ayon_core.pipeline import (
     Creator,
     HiddenCreator,
@@ -332,13 +331,13 @@ class SequenceLoader(LoaderPlugin):
     """
 
     options = [
-        qargparse.Boolean(
+        BoolDef(
             "handles",
             label="Include handles",
-            default=0,
+            default=False,
             help="Load with handles or without?"
         ),
-        qargparse.Choice(
+        EnumDef(
             "load_to",
             label="Where to load clips",
             items=[
@@ -348,7 +347,7 @@ class SequenceLoader(LoaderPlugin):
             default="Current timeline",
             help="Where do you want clips to be loaded?"
         ),
-        qargparse.Choice(
+        EnumDef(
             "load_how",
             label="How to load clips",
             items=[

--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -335,7 +335,7 @@ class SequenceLoader(LoaderPlugin):
             "handles",
             label="Include handles",
             default=False,
-            help="Load with handles or without?"
+            tooltip="Load with handles or without?"
         ),
         EnumDef(
             "load_to",
@@ -345,7 +345,7 @@ class SequenceLoader(LoaderPlugin):
                 "New timeline"
             ],
             default="Current timeline",
-            help="Where do you want clips to be loaded?"
+            tooltip="Where do you want clips to be loaded?"
         ),
         EnumDef(
             "load_how",
@@ -355,7 +355,7 @@ class SequenceLoader(LoaderPlugin):
                 "Sequentially in order"
             ],
             default="Original timing",
-            help="Would you like to place it at original timing?"
+            tooltip="Would you like to place it at original timing?"
         )
     ]
 


### PR DESCRIPTION
## Changelog Description

Replace qargparse with attribute definitions

## Additional review information

Clean up usage of `qargparse` and starting using AYON's attribute definitons.

## Testing notes:

1. Load options should still work
