### PR TITLE
Fix LoadClip not respecting product type settings

### DIFF
--- a/server/settings/loader_plugins.py
+++ b/server/settings/loader_plugins.py
@@ -6,9 +6,9 @@ class LoadClipModel(BaseSettingsModel):
         True,
         title="Enabled"
     )
-    product_types: list[str] = SettingsField(
+    product_base_types: list[str] = SettingsField(
         default_factory=list,
-        title="Product types"
+        title="Product base types"
     )
     clip_name_template: str = SettingsField(
         title="Clip name template"

--- a/server/settings/loader_plugins.py
+++ b/server/settings/loader_plugins.py
@@ -25,7 +25,7 @@ class LoaderPluginsModel(BaseSettingsModel):
 DEFAULT_LOADER_PLUGINS_SETTINGS = {
     "LoadClip": {
         "enabled": True,
-        "product_types": [
+        "product_base_types": [
             "render2d",
             "source",
             "plate",


### PR DESCRIPTION
This PR fixes issue #154. 

## Changelog Description

LoadClip settings now use product base types, aligning the server settings model with the loader plugin filtering behavior. 

## Additional review information

This PR updates the `LoadClip` settings schema from `product_types` to `product_base_types`, matching the loader plugin attributes used by Hiero loaders.


## Testing notes:

1. Go to `LoadClip` settings.
2. Confirm the setting is shown as `Product base types`.
3. Add or verify values such as `render2d`, `source`, `plate`, `render`, `review`, `prerender` .
4. Load a clip using `LoadClip` and confirm compatible products are still available.
