### PR TITLE
Fix clip effect publishing for Hiero clips with multiple tags 

### DIFF
--- a/client/ayon_hiero/plugins/publish/collect_clip_effects.py
+++ b/client/ayon_hiero/plugins/publish/collect_clip_effects.py
@@ -154,7 +154,8 @@ class CollectClipEffects(pyblish.api.InstancePlugin):
                     "clipEffectItems",
                     "trackItem",
                     "transientData",
-                    "subtracks"
+                    "subtracks",
+                    "tags",
                 )
             }
             data = copy.deepcopy(inherit_data)


### PR DESCRIPTION
This PR fixes #156 

## Changelog Description

Fixed clip effect publishing for tagged clips. Tag data containing native Hiero objects is no longer copied into effect instances, preventing deep-copy errors during collection.

## Additional review information

The clip effect collector inherits data from the source clip instance using `copy.deepcopy`. The `tags` field may contain native Hiero objects that cannot be deep-copied.

This change adds `tags` to the existing list of transient Hiero data excluded from effect instances.

## Testing notes:
1. Open a Hiero timeline containing a  clip with one or more effects.
2. Create a publish instance for the clip and configure it to publish effects.
3. Add one or multiple tags to that clip (it should have already the AYON tag so with another one it should work).
4. Run the publish.
5. Verify that clip effect collection completes without a deep-copy error.
6. Verify that the expected effect instance is created and published successfully.