### PR TITLE
Load Clip: Allow loading any media matching by extension

### DIFF
--- a/client/ayon_hiero/plugins/load/load_clip.py
+++ b/client/ayon_hiero/plugins/load/load_clip.py
@@ -15,7 +15,7 @@ class LoadClip(phiero.SequenceLoader):
     during conforming to project
     """
 
-    product_base_types = {"render2d", "source", "plate", "render", "review"}
+    product_base_types = {"*"}
     product_types = product_base_types
     representations = {"*"}
     extensions = set(

--- a/server/settings/loader_plugins.py
+++ b/server/settings/loader_plugins.py
@@ -6,10 +6,6 @@ class LoadClipModel(BaseSettingsModel):
         True,
         title="Enabled"
     )
-    product_types: list[str] = SettingsField(
-        default_factory=list,
-        title="Product types"
-    )
     clip_name_template: str = SettingsField(
         title="Clip name template"
     )
@@ -25,13 +21,6 @@ class LoaderPluginsModel(BaseSettingsModel):
 DEFAULT_LOADER_PLUGINS_SETTINGS = {
     "LoadClip": {
         "enabled": True,
-        "product_types": [
-            "render2d",
-            "source",
-            "plate",
-            "render",
-            "review"
-        ],
         "clip_name_template": "{folder[name]}_{product[name]}_{representation}"
     }
 }


### PR DESCRIPTION
## Changelog Description

Load Clip: Allow loading any representation matching the extension, regardless of product type.

## Additional review information

Alternative implementation for #155 
Fix https://github.com/ynput/ayon-hiero/issues/154

## Testing notes:

1. Load Clip should be available when relevant.
