### PR TITLE
Chore: Use new editorial families

### DIFF
--- a/client/ayon_hiero/plugins/publish/collect_current_file.py
+++ b/client/ayon_hiero/plugins/publish/collect_current_file.py
@@ -2,10 +2,10 @@ import pyblish.api
 from ayon_core.pipeline import registered_host
 
 
-class CollectWorkfile(pyblish.api.ContextPlugin):
+class CollectCurrentFile(pyblish.api.ContextPlugin):
     """Collect the current working file into context"""
 
-    label = "Collect Workfile"
+    label = "Collect Current File"
     hosts = ["hiero"]
     order = pyblish.api.CollectorOrder - 0.5
 

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -17,7 +17,15 @@ class CollectPlate(pyblish.api.InstancePlugin):
         Args:
             instance (pyblish.Instance): The shot instance to update.
         """
-        instance.data["families"].append("clip")
+        instance.data["families"].extend([
+            "clip",
+            # Mark for 'CollectOTIORanges' in core
+            "otio.clip.ranges",
+            # Mark for 'CollectOTIOProductResources' in core
+            "otio.clip.resources",
+            # Mark for 'CollectOTIOReviewTrack' in core
+            "otio.review.track",
+        ])
 
         # Adjust instance data from parent otio timeline.
         otio_timeline = instance.context.data["otioTimeline"]
@@ -56,6 +64,8 @@ class CollectPlate(pyblish.api.InstancePlugin):
         if review_switch is True:
             if reviewable_source == "clip_media":
                 instance.data["families"].append("review")
+                # Mark instance for 'ExtractOTIOReview' in core
+                instance.data["families"].append("otio.clip.review")
                 instance.data.pop("reviewTrack", None)
             else:
                 instance.data["reviewTrack"] = reviewable_source

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -64,6 +64,8 @@ class CollectPlate(pyblish.api.InstancePlugin):
         if review_switch is True:
             if reviewable_source == "clip_media":
                 instance.data["families"].append("review")
+                # Tell 'CollectOTIOReviewTrack' to use the current clip
+                instance.data["otioReviewClips"] = [otio_clip]
                 instance.data.pop("reviewTrack", None)
             else:
                 instance.data["reviewTrack"] = reviewable_source

--- a/client/ayon_hiero/plugins/publish/collect_plates.py
+++ b/client/ayon_hiero/plugins/publish/collect_plates.py
@@ -64,8 +64,6 @@ class CollectPlate(pyblish.api.InstancePlugin):
         if review_switch is True:
             if reviewable_source == "clip_media":
                 instance.data["families"].append("review")
-                # Mark instance for 'ExtractOTIOReview' in core
-                instance.data["families"].append("otio.clip.review")
                 instance.data.pop("reviewTrack", None)
             else:
                 instance.data["reviewTrack"] = reviewable_source

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -34,7 +34,7 @@ class CollectShot(pyblish.api.InstancePlugin):
         Args:
             instance (obj): The publishing instance.
         """
-        # Mark instance for 'CollectOtioRanges'
+        # Mark instance for 'CollectOTIORanges'
         instance.data["families"].append("otio.clip.ranges")
 
         context = instance.context

--- a/client/ayon_hiero/plugins/publish/collect_shots.py
+++ b/client/ayon_hiero/plugins/publish/collect_shots.py
@@ -34,6 +34,9 @@ class CollectShot(pyblish.api.InstancePlugin):
         Args:
             instance (obj): The publishing instance.
         """
+        # Mark instance for 'CollectOtioRanges'
+        instance.data["families"].append("otio.clip.ranges")
+
         context = instance.context
         instance_id = instance.data["instance_id"]
 

--- a/client/ayon_hiero/plugins/publish/collect_workfile.py
+++ b/client/ayon_hiero/plugins/publish/collect_workfile.py
@@ -5,7 +5,7 @@ class CollectWorkfile(pyblish.api.InstancePlugin):
     """Collect additional metadata for workfile instance."""
 
     label = "Collect Workfile"
-    order = pyblish.api.CollectorOrder - 0.45
+    order = pyblish.api.CollectorOrder - 0.49
     hosts = ["hiero"]
     families = ["workfile"]
 

--- a/client/ayon_hiero/plugins/publish/collect_workfile.py
+++ b/client/ayon_hiero/plugins/publish/collect_workfile.py
@@ -1,0 +1,14 @@
+import pyblish.api
+
+
+class CollectWorkfile(pyblish.api.InstancePlugin):
+    """Collect additional metadata for workfile instance."""
+
+    label = "Collect Workfile"
+    order = pyblish.api.CollectorOrder - 0.4
+    hosts = ["hiero"]
+    families = ["workfile"]
+
+    def process(self, instance):
+        # Mark instance for 'ExtractOTIOFile' in core
+        instance.data["families"].append("otio.timeline.workfile")

--- a/client/ayon_hiero/plugins/publish/collect_workfile.py
+++ b/client/ayon_hiero/plugins/publish/collect_workfile.py
@@ -5,7 +5,7 @@ class CollectWorkfile(pyblish.api.InstancePlugin):
     """Collect additional metadata for workfile instance."""
 
     label = "Collect Workfile"
-    order = pyblish.api.CollectorOrder - 0.4
+    order = pyblish.api.CollectorOrder - 0.45
     hosts = ["hiero"]
     families = ["workfile"]
 


### PR DESCRIPTION
## Changelog Description
Use new families defined in core to process editorial instances.

## Additional review information
[This PR](https://github.com/ynput/ayon-core/pull/1967) in ayon core is adding new families that are used to explicitly process instances instead of host based processing.

This PR is adding the families but should still work with old core. The same the core PR should work with hiero develop.

## Testing notes:
All possible combinations of ayon-core and ayon-hiero should produce exactly same output.
- hiero develop + core develop
- hiero PR + core PR
- hiero PR + core develop
- hiero develop + core PR
