### PR TITLE
Add Project and Shot Directories etc as Favorite Directories in File Browser

### DIFF
--- a/client/ayon_hiero/api/events.py
+++ b/client/ayon_hiero/api/events.py
@@ -18,7 +18,7 @@ log = Logger.get_logger(__name__)
 
 
 def startupCompleted(event):
-    log.info("startup competed event...")
+    log.info("startup completed event...")
     # create favorites in nuke's browser
     set_favorites()
     return

--- a/client/ayon_hiero/api/events.py
+++ b/client/ayon_hiero/api/events.py
@@ -8,7 +8,8 @@ from .lib import (
     sync_avalon_data_to_workfile,
     launch_workfiles_app,
     before_project_save,
-    apply_colorspace_project
+    apply_colorspace_project,
+    set_favorites,
 )
 from .tags import add_tags_to_workfile
 from .menu import update_menu_task_label
@@ -18,6 +19,8 @@ log = Logger.get_logger(__name__)
 
 def startupCompleted(event):
     log.info("startup competed event...")
+    # create favorites in nuke's browser
+    set_favorites()
     return
 
 
@@ -111,7 +114,7 @@ def register_hiero_events():
     #     "kAfterProjectClose", afterProjectClosed)
     #
     # hiero.core.events.registerInterest("kShutdown", shutDown)
-    # hiero.core.events.registerInterest("kStartup", startupCompleted)
+    hiero.core.events.registerInterest("kStartup", startupCompleted)
 
     # INFO: was disabled because it was slowing down timeline operations
     # hiero.core.events.registerInterest(

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -14,7 +14,6 @@ import secrets
 import hiero
 import nuke
 
-from collections import OrderedDict
 from qtpy import QtWidgets, QtCore
 import ayon_api
 from qtpy import QtXml
@@ -26,7 +25,7 @@ from ayon_core.pipeline import (
     get_current_project_name,
     AYON_INSTANCE_ID,
     AVALON_INSTANCE_ID,
-    get_current_folder_path,
+    registered_host,
 )
 from ayon_core.pipeline.load import filter_containers
 from ayon_core.lib import Logger
@@ -1301,19 +1300,22 @@ def get_main_window():
 
 
 def set_favorites() -> None:
-    """Adding favorite folders to nuke's browser"""
+    """Adding favorite folders to nuke's browser
+    This only works when specific templates are used for workfiles and folders,
+    otherwise it will not be able to find the correct paths.
+    """
     work_dir = os.getenv("AYON_WORKDIR")
-    
+
     # Use workdir from current workfile
     host = registered_host()
     workfile_path = os.path.normpath(host.get_current_workfile())
     if workfile_path:
         work_dir = os.path.dirname(workfile_path)
-        
+
     # Escape backslashes on windows
     if platform.system().lower() == "windows":
         work_dir = work_dir.replace("\\", "/")
-    
+
     context = host.get_current_context()
     project_name = context["project_name"]
     folder_path = context["folder_path"]
@@ -1324,7 +1326,7 @@ def set_favorites() -> None:
     project_dir = f"{projects_root}{project_name}/"
 
     folder_root = work_dir.split(folder_name)[0]
-    folder_dir = f"{folder_root}{folder_name}/"    
+    folder_dir = f"{folder_root}{folder_name}/"
 
     icon_path = resources.get_resource("icons", "folder-favorite.png")
     for name, path in (

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -1326,8 +1326,7 @@ def set_favorites() -> None:
     current_file = host.get_current_workfile()
     if current_file is not None:
         workfile_path = os.path.normpath(current_file)
-        if workfile_path:
-            work_dir = os.path.dirname(workfile_path)
+        work_dir = os.path.dirname(workfile_path)
 
     # Escape backslashes on windows
     if platform.system().lower() == "windows":

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -1300,22 +1300,6 @@ def get_main_window():
     return _CTX.parent_gui
 
 
-def set_context_favorites(favorites=None) -> None:
-    """Adding favorite folders to nuke's browser
-
-    Args:
-        favorites (dict): couples of {name:path}
-    """
-    favorites = favorites or {}
-    icon_path = resources.get_resource("icons", "folder-favorite.png")
-    for name, path in favorites.items():
-        nuke.addFavoriteDir(
-            name=name,
-            directory=path,
-            type=nuke.IMAGE | nuke.SCRIPT,
-            icon=icon_path)
-
-
 def set_favorites() -> None:
     """Adding favorite folders to nuke's browser"""
     work_dir = os.getenv("AYON_WORKDIR")

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -1325,8 +1325,7 @@ def set_favorites() -> None:
     host = registered_host()
     current_file = host.get_current_workfile()
     if current_file is not None:
-        workfile_path = os.path.normpath(current_file)
-        work_dir = os.path.dirname(workfile_path)
+        work_dir = os.path.dirname(current_file)
 
     # Escape backslashes on windows
     if platform.system().lower() == "windows":

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -1300,9 +1300,24 @@ def get_main_window():
 
 
 def set_favorites() -> None:
-    """Adding favorite folders to nuke's browser
-    This only works when specific templates are used for workfiles and folders,
-    otherwise it will not be able to find the correct paths.
+    """Add context-related favorites to Nuke's file browser.
+
+    Favorites are derived from ``AYON_WORKDIR`` (or the currently opened
+    workfile path) and split into:
+    - project directory
+    - folder directory
+    - work directory
+
+    Important limitations:
+    - Project root detection assumes ``project_name`` is present in the path.
+        If the project name is missing, or appears in an unexpected position,
+        derived project paths may be incorrect.
+    - Folder root detection assumes ``folder_name`` is present and uniquely
+        identifiable in the path. If the folder name is missing or repeated,
+        derived folder paths may be incorrect.
+
+    In short, path derivation is template-dependent and works best when the
+    current context tokens are explicitly represented in the work directory.
     """
     work_dir = os.getenv("AYON_WORKDIR")
 
@@ -1320,6 +1335,7 @@ def set_favorites() -> None:
     project_name = context["project_name"]
     folder_path = context["folder_path"]
     folder_name = folder_path.split("/")[-1]
+    print(f"Setting favorites for project: {project_name}, folder: {folder_name}")
 
     # Split workdir to parts by project name
     projects_root = work_dir.split(project_name)[0]
@@ -1329,11 +1345,13 @@ def set_favorites() -> None:
     folder_dir = f"{folder_root}{folder_name}/"
 
     icon_path = resources.get_resource("icons", "folder-favorite.png")
+    print("Adding favorite folders to nuke's browser:")
     for name, path in (
         ("Shot dir", folder_dir),
         ("Work dir", work_dir),
         ("Project dir", project_dir),
     ):
+        print(f"  {name}: {path}")
         nuke.addFavoriteDir(
             name=name,
             directory=path,

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -1348,6 +1348,10 @@ def set_favorites() -> None:
         ("Work dir", work_dir),
         ("Project dir", project_dir),
     ):
+        # This only adds the favorite directory to the "Import File(s)"
+        # and "Import Folder(s)" menus. It does not impact "Import EDL"
+        # nor "Import OTIO" as those are handled natively by Hiero with
+        # no public API.
         nuke.addFavoriteDir(
             name=name,
             directory=path,

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -12,17 +12,21 @@ import json
 import ast
 import secrets
 import hiero
+import nuke
 
+from collections import OrderedDict
 from qtpy import QtWidgets, QtCore
 import ayon_api
 from qtpy import QtXml
 
+from ayon_core import resources
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import (
     Anatomy,
     get_current_project_name,
     AYON_INSTANCE_ID,
     AVALON_INSTANCE_ID,
+    get_current_folder_path,
 )
 from ayon_core.pipeline.load import filter_containers
 from ayon_core.lib import Logger
@@ -1294,3 +1298,49 @@ def get_main_window():
                            widget.metaObject().className() == name)
         _CTX.parent_gui = main_window
     return _CTX.parent_gui
+
+
+def set_context_favorites(favorites=None) -> None:
+    """Adding favorite folders to nuke's browser
+
+    Args:
+        favorites (dict): couples of {name:path}
+    """
+    favorites = favorites or {}
+    icon_path = resources.get_resource("icons", "folder-favorite.png")
+    for name, path in favorites.items():
+        nuke.addFavoriteDir(
+            name=name,
+            directory=path,
+            type=nuke.IMAGE | nuke.SCRIPT,
+            icon=icon_path)
+
+
+def set_favorites() -> None:
+    """Adding favorite folders to nuke's browser"""
+    work_dir = os.getenv("AYON_WORKDIR")
+    folder_path = get_current_folder_path()
+    folder_name = folder_path.split("/")[-1]
+    favorite_items = OrderedDict()
+    project_name = get_current_project_name()
+    # project
+    # get project's root and split to parts
+    projects_root = os.path.normpath(
+        work_dir.split(project_name)[0])
+    # add project name
+    project_dir = os.path.join(projects_root, project_name) + "/"
+    # add to favorites
+    favorite_items.update({"Project dir": project_dir.replace("\\", "/")})
+
+    # folder
+    folder_root = os.path.normpath(work_dir.split(
+        folder_name)[0])
+    # add folder name
+    folder_dir = os.path.join(folder_root, folder_name) + "/"
+    # add to favorites
+    favorite_items.update({"Shot dir": folder_dir.replace("\\", "/")})
+
+    # workdir
+    favorite_items.update({"Work dir": work_dir.replace("\\", "/")})
+
+    set_context_favorites(favorite_items)

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -1323,9 +1323,11 @@ def set_favorites() -> None:
 
     # Use workdir from current workfile
     host = registered_host()
-    workfile_path = os.path.normpath(host.get_current_workfile())
-    if workfile_path:
-        work_dir = os.path.dirname(workfile_path)
+    current_file = host.get_current_workfile()
+    if current_file is not None:
+        workfile_path = os.path.normpath(current_file)
+        if workfile_path:
+            work_dir = os.path.dirname(workfile_path)
 
     # Escape backslashes on windows
     if platform.system().lower() == "windows":
@@ -1335,7 +1337,6 @@ def set_favorites() -> None:
     project_name = context["project_name"]
     folder_path = context["folder_path"]
     folder_name = folder_path.split("/")[-1]
-    print(f"Setting favorites for project: {project_name}, folder: {folder_name}")
 
     # Split workdir to parts by project name
     projects_root = work_dir.split(project_name)[0]
@@ -1345,13 +1346,11 @@ def set_favorites() -> None:
     folder_dir = f"{folder_root}{folder_name}/"
 
     icon_path = resources.get_resource("icons", "folder-favorite.png")
-    print("Adding favorite folders to nuke's browser:")
     for name, path in (
         ("Shot dir", folder_dir),
         ("Work dir", work_dir),
         ("Project dir", project_dir),
     ):
-        print(f"  {name}: {path}")
         nuke.addFavoriteDir(
             name=name,
             directory=path,

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -1324,9 +1324,8 @@ def set_favorites() -> None:
     # Use workdir from current workfile
     host = registered_host()
     current_file = host.get_current_workfile()
-    if current_file is not None:
+    if current_file:
         work_dir = os.path.dirname(current_file)
-
     # Escape backslashes on windows
     if platform.system().lower() == "windows":
         work_dir = work_dir.replace("\\", "/")

--- a/client/ayon_hiero/api/lib.py
+++ b/client/ayon_hiero/api/lib.py
@@ -1319,28 +1319,38 @@ def set_context_favorites(favorites=None) -> None:
 def set_favorites() -> None:
     """Adding favorite folders to nuke's browser"""
     work_dir = os.getenv("AYON_WORKDIR")
-    folder_path = get_current_folder_path()
+    
+    # Use workdir from current workfile
+    host = registered_host()
+    workfile_path = os.path.normpath(host.get_current_workfile())
+    if workfile_path:
+        work_dir = os.path.dirname(workfile_path)
+        
+    # Escape backslashes on windows
+    if platform.system().lower() == "windows":
+        work_dir = work_dir.replace("\\", "/")
+    
+    context = host.get_current_context()
+    project_name = context["project_name"]
+    folder_path = context["folder_path"]
     folder_name = folder_path.split("/")[-1]
-    favorite_items = OrderedDict()
-    project_name = get_current_project_name()
-    # project
-    # get project's root and split to parts
-    projects_root = os.path.normpath(
-        work_dir.split(project_name)[0])
-    # add project name
-    project_dir = os.path.join(projects_root, project_name) + "/"
-    # add to favorites
-    favorite_items.update({"Project dir": project_dir.replace("\\", "/")})
 
-    # folder
-    folder_root = os.path.normpath(work_dir.split(
-        folder_name)[0])
-    # add folder name
-    folder_dir = os.path.join(folder_root, folder_name) + "/"
-    # add to favorites
-    favorite_items.update({"Shot dir": folder_dir.replace("\\", "/")})
+    # Split workdir to parts by project name
+    projects_root = work_dir.split(project_name)[0]
+    project_dir = f"{projects_root}{project_name}/"
 
-    # workdir
-    favorite_items.update({"Work dir": work_dir.replace("\\", "/")})
+    folder_root = work_dir.split(folder_name)[0]
+    folder_dir = f"{folder_root}{folder_name}/"    
 
-    set_context_favorites(favorite_items)
+    icon_path = resources.get_resource("icons", "folder-favorite.png")
+    for name, path in (
+        ("Shot dir", folder_dir),
+        ("Work dir", work_dir),
+        ("Project dir", project_dir),
+    ):
+        nuke.addFavoriteDir(
+            name=name,
+            directory=path,
+            type=nuke.IMAGE | nuke.SCRIPT,
+            icon=icon_path,
+        )

--- a/client/ayon_hiero/api/workio.py
+++ b/client/ayon_hiero/api/workio.py
@@ -62,7 +62,10 @@ def open_file(filepath):
 
 
 def current_file():
-    current_file = hiero.core.projects()[-1].path()
+    projects = hiero.core.projects()
+    if not projects:
+        return None
+    current_file = projects[-1].path()
     if not current_file:
         return None
     return os.path.normpath(current_file)


### PR DESCRIPTION
## Changelog Description
This PR is to add directories (e.g. Project and Shot) as favorite directories in file browser, like we did in Nuke. 
Fixes https://github.com/ynput/ayon-hiero/issues/46


## Additional review information
n/a

## Testing notes:
1. Build addon with this PR
2. Launch Hiero/Nuke Studio
3. Open File Browser
4. You would find the Project, shot directories label.
