### PR TITLE
Fix incorrect product name collisions in vertical sync

### DIFF
--- a/client/ayon_hiero/api/plugin.py
+++ b/client/ayon_hiero/api/plugin.py
@@ -1011,7 +1011,7 @@ class PublishClip:
             variant = self.variant
 
             # If hero clip product name matches this clip's, append track index
-            if clip_product_name in data_product_name:
+            if clip_product_name == data_product_name:
                 clip_product_name = f"{clip_product_name}{self.track_index}"
                 variant = f"{variant}{self.track_index}"
 


### PR DESCRIPTION
This PR fixes #162 

## Changelog Description
Fixed an issue where vertical sync incorrectly added suffixes to distinct products with overlapping names. Product names are now considered duplicates only when they match exactly.

## Additional review information
The vertical-sync uniqueness check used substring matching to compare the current clip product name with the hero clip product name. As a result, distinct names could be treated as duplicates when one was contained within the other—for example, `GFX` and `GFXRef`.

The comparison now uses exact equality. Existing duplicate handling remains unchanged: genuine duplicate products still receive a suffix through the subsequent used-name check.

## Testing notes 

1. Create two vertically aligned tracks with overlapping names, such as `GFX` and `GFXRef`.
2. Add two clips to `GFX` beneath one hero clip on `GFXRef`.
3. Select all three clips enable vertical sync, select `GFXRef` as the hero track and create the clip instances.
5. Confirm that the resulting variants are `GFX`, `GFX2`, and `GFXRef`.
6. Confirm that only the genuine duplicate `GFX` product receives a suffix and that the vertically synchronized instance data remains correct.